### PR TITLE
fix(query.infinite): remove withCursor, add hasMore guard

### DIFF
--- a/packages/mucha/src/core/query.ts
+++ b/packages/mucha/src/core/query.ts
@@ -392,23 +392,6 @@ function parseQueryArgs(args: unknown[]) {
   }
 }
 
-function withCursor(arg: unknown, cursor: string | null | undefined) {
-  if (cursor === undefined || cursor === null) {
-    return arg
-  }
-
-  if (isRecord(arg)) {
-    return {
-      ...arg,
-      cursor,
-    }
-  }
-
-  return {
-    cursor,
-  }
-}
-
 function stableSerialize(value: unknown, seen = new WeakSet<object>()): unknown {
   if (value === null || typeof value !== 'object') return value
   if (value instanceof Date) return value.toISOString()
@@ -704,12 +687,12 @@ function createResourceAccessor(
   const nextFetch = (...rawArgs: unknown[]) => {
     const parsed = parseQueryArgs(rawArgs)
     if (descriptor.kind !== 'infinite') return
+    if (!(state as ResourceInfiniteState<unknown>).hasMore) return
     const active = getActiveEntry()
     if (!active) return
 
-    const cursor = (state as ResourceInfiniteState<unknown>).cursor
-    const nextArg = withCursor(parsed.hasArg ? parsed.arg : active.arg, cursor)
-    return executeQuery(nextArg, parsed.options, true, 'append', false)
+    const effectiveArg = parsed.hasArg ? parsed.arg : active.arg
+    return executeQuery(effectiveArg, parsed.options, true, 'append', false)
   }
 
   const previousFetch = (...rawArgs: unknown[]) => {
@@ -723,9 +706,8 @@ function createResourceAccessor(
     }
 
     active.cursorHistory.pop()
-    const prevCursor = active.cursorHistory[active.cursorHistory.length - 1]
-    const previousArg = withCursor(parsed.hasArg ? parsed.arg : active.arg, prevCursor)
-    return executeQuery(previousArg, parsed.options, true, 'replace', false)
+    const effectiveArg = parsed.hasArg ? parsed.arg : active.arg
+    return executeQuery(effectiveArg, parsed.options, true, 'replace', false)
   }
 
   const bound = new Proxy(state, {


### PR DESCRIPTION
## Summary

- **Remove `withCursor`** — it silently dropped primitive args on `nextFetch()`. e.g. a string enum filter like `'announcement'` was replaced by `{ cursor: '2' }`, losing the filter entirely
- **Unify cursor access** — cursor is now only accessible via `context.state.cursor` in queryFn. No more dual-path confusion (arg injection vs context)
- **Add `hasMore` guard in `nextFetch`** — early returns when `hasMore === false`, so consumers don't need manual guards

Closes #14

## Changes

| Before | After |
|--------|-------|
| `nextFetch` calls `withCursor(arg, cursor)` which corrupts primitive args | `nextFetch` passes original arg as-is; cursor via `context.state.cursor` |
| No `hasMore` check in `nextFetch` — consumers must guard | `nextFetch` auto-returns when `hasMore === false` |
| `withCursor` function (17 lines) | Removed |

## Test plan

- [ ] Verify `nextFetch()` preserves primitive args (string enum filters)
- [ ] Verify `nextFetch()` no-ops when `hasMore === false`
- [ ] Verify `previousFetch()` works without cursor arg injection
- [ ] Verify `context.state.cursor` is accessible in queryFn for cursor-based pagination
- [ ] Library builds successfully (`yarn dev:lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)