### PR TITLE
fix(comwit): fix 5 query bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,30 @@ All from `'comwit'`. Stack on class methods.
 
 `createInterceptor(({ state, context }) => MethodDecorator)` — reusable decorator with `state`/`context` access, like action factories. See [actions](#actionsts) above for usage.
 
+## Infinite Query Return Shape
+
+`queryFn` for `query.infinite()` must return `{ data, cursor?, hasMore? }`:
+
+```ts
+queryFn: (_, { state }) => {
+  const res = await api.post.trending(state.cursor)
+  return { data: res.items, cursor: res.nextCursor, hasMore: res.hasNext }
+}
+```
+
+Without `hasMore: true` in the response, `nextFetch()` is a no-op.
+
+## Query Lifecycle
+
+```
+query() defined in model → .query() called in action → data loaded
+  → (infinite) response includes hasMore: true → nextFetch() enabled
+  → within staleTime → cache returned, no fetch
+  → after gcTime → cache entry deleted
+```
+
+`.query()` must be called at least once before `refetch()` or `nextFetch()` will work.
+
 ## Key Concepts
 
 - `model(initial)` — global reactive store

--- a/packages/comwit/src/core/query.ts
+++ b/packages/comwit/src/core/query.ts
@@ -177,7 +177,7 @@ type ResourceFactory = {
   ) => InfiniteResourceDescriptor<TData, TArg>
 }
 
-type QueryMode = 'replace' | 'append'
+type QueryMode = 'replace' | 'append' | 'restore'
 
 type QueryCacheKey = string
 
@@ -210,6 +210,7 @@ type ResourceRuntimeState = {
   path: string
   lastArg?: unknown
   activeKey?: QueryCacheKey
+  fetchId: number
   cacheEntries: Map<QueryCacheKey, QueryCacheEntry>
 }
 
@@ -430,6 +431,7 @@ function cloneRuntime(path: string): ResourceRuntimeState {
     path,
     lastArg: undefined,
     activeKey: undefined,
+    fetchId: 0,
     cacheEntries: new Map(),
   }
 }
@@ -597,7 +599,7 @@ function createResourceAccessor(
       effectiveOptions.placeholderData as PlaceholderData<unknown, unknown> | undefined
     )
 
-    if (descriptor.kind === 'infinite') {
+    if (descriptor.kind === 'infinite' && mode !== 'restore') {
       const infiniteHistory = entry.cursorHistory
       const currentCursor = (state as ResourceInfiniteState<unknown>).cursor
 
@@ -616,10 +618,12 @@ function createResourceAccessor(
       }
     }
 
-    state.isLoading = !state.isSuccess && !state.isError
-    state.isFetching = true
     state.isError = false
     state.error = null
+    state.isLoading = !state.isSuccess
+    state.isFetching = true
+
+    const currentFetchId = ++runtime.fetchId
 
     try {
       let result: unknown
@@ -630,16 +634,21 @@ function createResourceAccessor(
           queryArg as unknown,
           contextFor(state) as ResourceContext<ResourceSingleState<unknown>>
         )
-
-        if (result !== undefined) {
-          state.data = result
-        }
       } else {
         const typedDescriptor = descriptor as InfiniteResourceDescriptor<unknown, unknown>
         result = await typedDescriptor.queryFn(
           queryArg as unknown,
           contextFor(state) as ResourceContext<ResourceInfiniteState<unknown>>
         )
+      }
+
+      if (runtime.fetchId !== currentFetchId) {
+        return result
+      }
+
+      if (descriptor.kind === 'single') {
+        mergeResult(state, result)
+      } else {
         mergeResult(state, result, mode === 'append')
       }
 
@@ -649,7 +658,7 @@ function createResourceAccessor(
       entry.lastResult = result
       updateCachedState(entry, state)
 
-      if (descriptor.kind === 'infinite') {
+      if (descriptor.kind === 'infinite' && mode !== 'restore') {
         const infiniteHistory = entry.cursorHistory
         const nextCursor = (state as ResourceInfiniteState<unknown>).cursor
 
@@ -662,13 +671,18 @@ function createResourceAccessor(
 
       return result
     } catch (error) {
+      if (runtime.fetchId !== currentFetchId) {
+        throw error
+      }
       state.isError = true
       state.isSuccess = false
       state.error = normalizeError(error)
       throw error
     } finally {
-      state.isLoading = false
-      state.isFetching = false
+      if (runtime.fetchId === currentFetchId) {
+        state.isLoading = false
+        state.isFetching = false
+      }
     }
   }
 
@@ -707,7 +721,7 @@ function createResourceAccessor(
 
     active.cursorHistory.pop()
     const effectiveArg = parsed.hasArg ? parsed.arg : active.arg
-    return executeQuery(effectiveArg, parsed.options, true, 'replace', false)
+    return executeQuery(effectiveArg, parsed.options, true, 'restore', false)
   }
 
   const bound = new Proxy(state, {
@@ -733,6 +747,12 @@ function createResourceAccessor(
           target.isSuccess = true
           target.isError = false
           target.error = null
+
+          const activeEntry = getActiveEntry()
+          if (activeEntry) {
+            updateCachedState(activeEntry, target)
+          }
+
           return next
         }
       }


### PR DESCRIPTION
## Summary

- **isLoading calculation order**: reset `isError` before computing `isLoading` so error-retry correctly shows loading state instead of silently staying `isLoading: false`
- **Stale response race condition**: add `fetchId` guard so when `query('a')` is in-flight and `query('b')` fires, the late response from 'a' no longer overwrites state
- **`set()` cache sync**: calling `set(newData)` now updates the cache entry, preventing staleTime reads from reverting to pre-set data
- **Single query `mergeResult`**: use `mergeResult()` for single queries so `{ data, ...flags }` return shape is handled consistently (previously only infinite queries used it)
- **`previousFetch` cursor history**: introduce `'restore'` query mode that preserves cursor history, enabling multi-step back navigation (previously truncated to 1 entry)

Also documents infinite query return shape (`{ data, cursor?, hasMore? }`) and query lifecycle in README.

## Test plan

- [ ] Verify error → retry shows loading skeleton (`isLoading: true`)
- [ ] Rapid query arg changes (autocomplete) — only latest response applies
- [ ] `set()` then `query()` within staleTime returns set data, not stale cache
- [ ] Single queryFn returning `{ data: [...] }` correctly unwraps
- [ ] Infinite list: page 1 → 2 → 3 → previousFetch → previousFetch reaches page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)