### PR TITLE
feat(query): add Suspense support for query() resources

### DIFF
--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useSyncExternalStore } from 'react'
 import { createProxy, snapshot, subscribe } from './proxy'
-import { isResourceDescriptor, ResourceDescriptorMap } from './query'
+import { isResourceDescriptor, ResourceDescriptorMap, checkSuspense } from './query'
 import { useStoreRegistry } from './provider'
 import { isEqual } from '../utils'
 import { isSilent } from './silent'
@@ -156,7 +156,14 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
     return next as R
   }
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const result = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  // Check suspense state — throws promise for Suspense or error for ErrorBoundary
+  if (m.resources.size > 0) {
+    checkSuspense(m.resources, registry.queryBinding)
+  }
+
+  return result
 }
 
 function normalize(value: unknown, path: string, resources: ResourceDescriptorMap): unknown {

--- a/packages/comwit/src/core/query.ts
+++ b/packages/comwit/src/core/query.ts
@@ -72,6 +72,8 @@ export type Query<TData, TArg = void> = SingleResourceDescriptor<TData, TArg>
 export namespace Query {
   export type Single<TData, TArg = void> = Query<TData, TArg>
   export type Infinite<TData, TArg = void> = InfiniteResourceDescriptor<TData, TArg>
+  export type Suspense<TData, TArg = void> = SingleResourceDescriptor<TData, TArg, true>
+  export type SuspenseInfinite<TData, TArg = void> = InfiniteResourceDescriptor<TData, TArg, true>
 }
 
 export type QueryInfinite<TData, TArg = void> = InfiniteResourceDescriptor<TData, TArg>
@@ -84,6 +86,7 @@ type InfiniteResourceLoadResult<TData> =
 type BaseResourceDescriptor<TState extends ResourceDataLike, TArg, TResult> = {
   [RESOURCE_BRAND]: true
   kind: ResourceKind
+  suspense?: boolean
   initialState: TState
   options: Omit<
     ResourceQueryOptions<TState extends ResourceBaseState<infer TData> ? TData : never, unknown>,
@@ -92,22 +95,24 @@ type BaseResourceDescriptor<TState extends ResourceDataLike, TArg, TResult> = {
   queryFn: (arg: TArg, context: ResourceContext<TState>) => AsyncResult<TResult>
 }
 
-type SingleResourceDescriptor<TData, TArg = void> = BaseResourceDescriptor<
-  ResourceSingleState<TData>,
-  TArg,
-  SingleResourceLoadResult<TData>
-> &
+type SingleResourceDescriptor<
+  TData,
+  TArg = void,
+  TSuspense extends boolean = false,
+> = BaseResourceDescriptor<ResourceSingleState<TData>, TArg, SingleResourceLoadResult<TData>> &
   ResourceSingleState<TData> & {
     kind: 'single'
+    __suspense?: TSuspense
   }
 
-type InfiniteResourceDescriptor<TData, TArg = void> = BaseResourceDescriptor<
-  ResourceInfiniteState<TData>,
-  TArg,
-  InfiniteResourceLoadResult<TData>
-> &
+type InfiniteResourceDescriptor<
+  TData,
+  TArg = void,
+  TSuspense extends boolean = false,
+> = BaseResourceDescriptor<ResourceInfiniteState<TData>, TArg, InfiniteResourceLoadResult<TData>> &
   ResourceInfiniteState<TData> & {
     kind: 'infinite'
+    __suspense?: TSuspense
   }
 
 export type AnyResourceDescriptor =
@@ -137,11 +142,24 @@ export type BoundSingleResourceState<TData, TArg = unknown> = ResourceSingleStat
 export type BoundInfiniteResourceState<TData, TArg = unknown> = ResourceInfiniteState<TData> &
   ResourceInfiniteQueryController<TData, TArg>
 
+type SuspenseSingleResourceState<TData, TArg = unknown> = Omit<
+  BoundSingleResourceState<TData, TArg>,
+  'data'
+> & { data: NonNullable<TData> }
+type SuspenseInfiniteResourceState<TData, TArg = unknown> = Omit<
+  BoundInfiniteResourceState<TData, TArg>,
+  'data'
+> & { data: NonNullable<TData> }
+
 export type BoundResourceState<T> =
-  T extends InfiniteResourceDescriptor<infer TData, infer TArg>
-    ? BoundInfiniteResourceState<TData, TArg>
-    : T extends SingleResourceDescriptor<infer TData, infer TArg>
-      ? BoundSingleResourceState<TData, TArg>
+  T extends InfiniteResourceDescriptor<infer TData, infer TArg, infer TSuspense>
+    ? TSuspense extends true
+      ? SuspenseInfiniteResourceState<TData, TArg>
+      : BoundInfiniteResourceState<TData, TArg>
+    : T extends SingleResourceDescriptor<infer TData, infer TArg, infer TSuspense>
+      ? TSuspense extends true
+        ? SuspenseSingleResourceState<TData, TArg>
+        : BoundSingleResourceState<TData, TArg>
       : T extends ResourceInfiniteState<infer TData>
         ? BoundInfiniteResourceState<TData, unknown>
         : T extends ResourceSingleState<infer TData>
@@ -154,6 +172,7 @@ export type BoundResourceState<T> =
 
 type SingleResourceBuilderOptions<TData, TArg = void> = {
   initialData: TData
+  suspense?: boolean
   queryFn: (
     arg: TArg,
     context: ResourceContext<ResourceSingleState<TData>>
@@ -162,6 +181,7 @@ type SingleResourceBuilderOptions<TData, TArg = void> = {
 
 type InfiniteResourceBuilderOptions<TData, TArg = void> = {
   initialData: TData
+  suspense?: boolean
   queryFn: (
     arg: TArg,
     context: ResourceContext<ResourceInfiniteState<TData>>
@@ -170,11 +190,19 @@ type InfiniteResourceBuilderOptions<TData, TArg = void> = {
 
 type ResourceFactory = {
   <TData, TArg = void>(
+    opts: SingleResourceBuilderOptions<TData, TArg> & { suspense: true }
+  ): SingleResourceDescriptor<TData, TArg, true>
+  <TData, TArg = void>(
     opts: SingleResourceBuilderOptions<TData, TArg>
   ): SingleResourceDescriptor<TData, TArg>
-  infinite: <TData, TArg = void>(
-    opts: InfiniteResourceBuilderOptions<TData, TArg>
-  ) => InfiniteResourceDescriptor<TData, TArg>
+  infinite: {
+    <TData, TArg = void>(
+      opts: InfiniteResourceBuilderOptions<TData, TArg> & { suspense: true }
+    ): InfiniteResourceDescriptor<TData, TArg, true>
+    <TData, TArg = void>(
+      opts: InfiniteResourceBuilderOptions<TData, TArg>
+    ): InfiniteResourceDescriptor<TData, TArg>
+  }
 }
 
 type QueryMode = 'replace' | 'append' | 'restore'
@@ -192,10 +220,16 @@ type QueryCacheEntry = {
   state: ResourceDataLike
 }
 
+export type SuspenseState = {
+  promise: Promise<unknown> | null
+  error: Error | null
+}
+
 export type QueryBindingRegistry = {
   boundResourceValue: WeakMap<object, Record<string, unknown>>
   boundPathProxy: WeakMap<object, Map<string, object>>
   boundResourceRuntime: WeakMap<object, ResourceRuntimeState>
+  suspense: Map<string, SuspenseState>
 }
 
 export function createQueryBindingRegistry(): QueryBindingRegistry {
@@ -203,6 +237,7 @@ export function createQueryBindingRegistry(): QueryBindingRegistry {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
     boundResourceRuntime: new WeakMap(),
+    suspense: new Map(),
   }
 }
 
@@ -228,6 +263,7 @@ function createSingleDescriptor<TData, TArg = void>(
 
   const {
     initialData: _initialData,
+    suspense,
     queryFn,
     ...optionValues
   } = opts as SingleResourceBuilderOptions<TData, TArg>
@@ -235,6 +271,7 @@ function createSingleDescriptor<TData, TArg = void>(
   return {
     ...initialState,
     kind: 'single',
+    suspense: suspense ?? false,
     [RESOURCE_BRAND]: true,
     initialState,
     options: optionValues as Omit<ResourceQueryOptions<TData, unknown>, 'force'>,
@@ -258,6 +295,7 @@ function createInfiniteDescriptor<TData, TArg = void>(
 
   const {
     initialData: _initialData,
+    suspense,
     queryFn,
     ...optionValues
   } = opts as InfiniteResourceBuilderOptions<TData, TArg>
@@ -265,6 +303,7 @@ function createInfiniteDescriptor<TData, TArg = void>(
   return {
     ...initialState,
     kind: 'infinite',
+    suspense: suspense ?? false,
     [RESOURCE_BRAND]: true,
     initialState,
     options: optionValues as Omit<ResourceQueryOptions<TData, unknown>, 'force'>,
@@ -623,6 +662,17 @@ function createResourceAccessor(
     state.isLoading = !state.isSuccess
     state.isFetching = true
 
+    // Track suspense promise for initial loads (not refetches)
+    if (descriptor.suspense && state.isLoading && !isRefetch) {
+      let resolvePromise!: () => void
+      const promise = new Promise<unknown>((resolve) => {
+        resolvePromise = resolve as () => void
+      })
+      registry.suspense.set(path, { promise, error: null })
+      // Store resolver on the state object for later cleanup
+      ;(registry.suspense.get(path) as any).__resolve = resolvePromise
+    }
+
     const currentFetchId = ++runtime.fetchId
 
     try {
@@ -677,11 +727,35 @@ function createResourceAccessor(
       state.isError = true
       state.isSuccess = false
       state.error = normalizeError(error)
+
+      // Store error in suspense state for ErrorBoundary
+      if (descriptor.suspense) {
+        const suspenseEntry = registry.suspense.get(path)
+        if (suspenseEntry) {
+          suspenseEntry.error = error instanceof Error ? error : new Error(normalizeError(error))
+          // Don't re-throw — let checkSuspense throw it during render
+          return
+        }
+      }
+
       throw error
     } finally {
       if (runtime.fetchId === currentFetchId) {
         state.isLoading = false
         state.isFetching = false
+
+        // Resolve suspense promise so React can re-render
+        if (descriptor.suspense) {
+          const suspenseEntry = registry.suspense.get(path)
+          if (suspenseEntry) {
+            const resolve = (suspenseEntry as any).__resolve as (() => void) | undefined
+            if (resolve) resolve()
+            // Only clean up if no error — error entries are cleaned up in checkSuspense
+            if (!suspenseEntry.error) {
+              registry.suspense.delete(path)
+            }
+          }
+        }
       }
     }
   }
@@ -822,4 +896,31 @@ export function bindResourceState<T extends object>(
 ): T {
   if (!resourceDescriptors.size) return modelState
   return bindPath(modelState, resourceDescriptors, '', defaults, registry) as T
+}
+
+/**
+ * Check suspense state for a model's resources and throw if needed.
+ * Call this during React render (after useSyncExternalStore) to trigger Suspense/ErrorBoundary.
+ */
+export function checkSuspense(
+  resourceDescriptors: ResourceDescriptorMap,
+  registry: QueryBindingRegistry
+): void {
+  for (const [path, descriptor] of resourceDescriptors) {
+    if (!descriptor.suspense) continue
+
+    const entry = registry.suspense.get(path)
+    if (!entry) continue
+
+    // If there's an error, throw it for ErrorBoundary
+    // Keep the entry so React's retry renders also throw
+    if (entry.error) {
+      throw entry.error
+    }
+
+    // If there's a pending promise, throw it for Suspense
+    if (entry.promise) {
+      throw entry.promise
+    }
+  }
 }

--- a/packages/comwit/tests/suspense.test.tsx
+++ b/packages/comwit/tests/suspense.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi } from 'vitest'
+import React, { Suspense, Component, type ReactNode } from 'react'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { model, useModel, action, useAction, create, ComwitProvider, query } from '../src'
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ComwitProvider>{children}</ComwitProvider>
+}
+
+class ErrorBoundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null }
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+  render() {
+    if (this.state.error) return this.props.fallback
+    return this.props.children
+  }
+}
+
+describe('Suspense support', () => {
+  test('component suspends until query resolves', async () => {
+    const d = deferred<string[]>()
+
+    const items = model({
+      list: query({
+        initialData: null as string[] | null,
+        suspense: true,
+        queryFn: () => d.promise,
+      }),
+    })
+
+    const fetchItems = action(({ state }) => ({
+      fetch() {
+        state(items).list.query()
+      },
+    }))
+
+    function ItemList() {
+      const s = useModel(items)
+      const actions = useAction<{ fetch: () => void }>([fetchItems])
+      React.useEffect(() => {
+        actions.fetch()
+      }, [])
+      return <div data-testid="data">{JSON.stringify(s.list.data)}</div>
+    }
+
+    render(
+      <Wrapper>
+        <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+          <ItemList />
+        </Suspense>
+      </Wrapper>
+    )
+
+    // Should show fallback while loading
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toBeDefined()
+    })
+
+    // Resolve the query
+    await act(async () => {
+      d.resolve(['a', 'b', 'c'])
+      await d.promise
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Should now show the data
+    await waitFor(() => {
+      expect(screen.getByTestId('data').textContent).toBe('["a","b","c"]')
+    })
+  })
+
+  test('component throws error to error boundary', async () => {
+    const d = deferred<string[]>()
+
+    const items = model({
+      list: query({
+        initialData: null as string[] | null,
+        suspense: true,
+        queryFn: () => d.promise,
+      }),
+    })
+
+    const fetchItems = action(({ state }) => ({
+      fetch() {
+        state(items).list.query()
+      },
+    }))
+
+    function ItemList() {
+      const s = useModel(items)
+      const actions = useAction<{ fetch: () => void }>([fetchItems])
+      React.useEffect(() => {
+        actions.fetch()
+      }, [])
+      return <div data-testid="data">{JSON.stringify(s.list.data)}</div>
+    }
+
+    render(
+      <Wrapper>
+        <ErrorBoundary fallback={<div data-testid="error">Error occurred</div>}>
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <ItemList />
+          </Suspense>
+        </ErrorBoundary>
+      </Wrapper>
+    )
+
+    // Should show suspense fallback while loading
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toBeDefined()
+    })
+
+    // Reject the query
+    await act(async () => {
+      d.reject(new Error('Network failure'))
+      try {
+        await d.promise
+      } catch {}
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Should show error boundary fallback
+    await waitFor(() => {
+      expect(screen.getByTestId('error')).toBeDefined()
+    })
+  })
+
+  test('refetch does NOT suspend', async () => {
+    let callCount = 0
+    const d1 = deferred<string[]>()
+    let d2: ReturnType<typeof deferred<string[]>>
+
+    const items = model({
+      list: query({
+        initialData: null as string[] | null,
+        suspense: true,
+        queryFn: () => {
+          callCount++
+          if (callCount === 1) return d1.promise
+          d2 = deferred<string[]>()
+          return d2.promise
+        },
+      }),
+    })
+
+    const fetchItems = action(({ state }) => ({
+      fetch() {
+        state(items).list.query()
+      },
+      refetch() {
+        state(items).list.refetch()
+      },
+    }))
+
+    let actionsRef: { fetch: () => void; refetch: () => void }
+
+    function ItemList() {
+      const s = useModel(items)
+      const actions = useAction<{ fetch: () => void; refetch: () => void }>([fetchItems])
+      actionsRef = actions
+      React.useEffect(() => {
+        actions.fetch()
+      }, [])
+      return (
+        <div>
+          <div data-testid="data">{JSON.stringify(s.list.data)}</div>
+          <div data-testid="fetching">{String(s.list.isFetching)}</div>
+        </div>
+      )
+    }
+
+    render(
+      <Wrapper>
+        <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+          <ItemList />
+        </Suspense>
+      </Wrapper>
+    )
+
+    // Initially suspended
+    await waitFor(() => {
+      expect(screen.getByTestId('loading')).toBeDefined()
+    })
+
+    // Resolve initial query
+    await act(async () => {
+      d1.resolve(['first'])
+      await d1.promise
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data').textContent).toBe('["first"]')
+    })
+
+    // Trigger refetch - should NOT suspend
+    await act(async () => {
+      actionsRef.refetch()
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    // The component should remain visible (not suspended) during refetch
+    expect(screen.queryByTestId('loading')).toBeNull()
+    expect(screen.getByTestId('data')).toBeDefined()
+
+    // Resolve refetch
+    await act(async () => {
+      d2!.resolve(['second'])
+      await d2!.promise
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data').textContent).toBe('["second"]')
+    })
+  })
+
+  test('non-suspense queries still work normally', async () => {
+    const d = deferred<string[]>()
+
+    const items = model({
+      list: query({
+        initialData: null as string[] | null,
+        queryFn: () => d.promise,
+      }),
+    })
+
+    const fetchItems = action(({ state }) => ({
+      fetch() {
+        state(items).list.query()
+      },
+    }))
+
+    function ItemList() {
+      const s = useModel(items)
+      const actions = useAction<{ fetch: () => void }>([fetchItems])
+      React.useEffect(() => {
+        actions.fetch()
+      }, [])
+      return (
+        <div>
+          <div data-testid="data">{JSON.stringify(s.list.data)}</div>
+          <div data-testid="loading-state">{String(s.list.isLoading)}</div>
+        </div>
+      )
+    }
+
+    render(
+      <Wrapper>
+        <Suspense fallback={<div data-testid="suspense-fallback">Suspended</div>}>
+          <ItemList />
+        </Suspense>
+      </Wrapper>
+    )
+
+    // Should NOT suspend - should render normally with initial data
+    expect(screen.queryByTestId('suspense-fallback')).toBeNull()
+    expect(screen.getByTestId('data').textContent).toBe('null')
+
+    // Resolve
+    await act(async () => {
+      d.resolve(['x', 'y'])
+      await d.promise
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data').textContent).toBe('["x","y"]')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `suspense: true` option to `query()` and `query.infinite()` descriptors
- Works through the existing `useModel()` / `create()` — no `useSuspense()` hook needed
- When enabled, throws pending promise during initial load (React Suspense catches it) and throws errors (ErrorBoundary catches them)
- Refetches do **not** trigger suspense — only the initial load suspends
- TypeScript: `data` is narrowed to `NonNullable<T>` when `suspense: true`

## Usage Example

### Define a suspense-enabled query

```ts
import { model, query, create, action } from 'comwit'

const userModel = model({
  // suspense: true — this query will suspend instead of returning isLoading
  profile: query<User>({
    initialData: null,
    queryFn: async () => {
      const res = await fetch('/api/user')
      return res.json()
    },
    suspense: true,  // <-- opt-in per query
  }),
})
```

### Use with React Suspense (same hook!)

```tsx
const useUser = create(userModel, { actions: [userActions] })

// No loading checks needed — Suspense handles it
function UserProfile() {
  const { profile } = useUser()

  // profile.data is User, NOT User | null
  // TypeScript knows data is guaranteed defined because suspense: true
  return <h1>{profile.data.name}</h1>
}

// Wrap with Suspense + ErrorBoundary
function App() {
  return (
    <ErrorBoundary fallback={<p>Something went wrong</p>}>
      <Suspense fallback={<Spinner />}>
        <UserProfile />
      </Suspense>
    </ErrorBoundary>
  )
}
```

### Refetch does NOT suspend

```tsx
function UserProfile() {
  const { profile, actions } = useUser()

  // Initial load → suspends (shows <Spinner />)
  // After data loaded → renders normally
  // Calling refetch → does NOT suspend again, shows stale data while fetching
  return (
    <div>
      <h1>{profile.data.name}</h1>
      <button onClick={() => profile.refetch()}>Refresh</button>
      {profile.isFetching && <small>Updating...</small>}
    </div>
  )
}
```

### Mix suspense and non-suspense queries

```ts
const dashboardModel = model({
  // Suspends — critical data, show fallback while loading
  user: query<User>({
    initialData: null,
    queryFn: fetchUser,
    suspense: true,
  }),

  // Does NOT suspend — optional data, handle loading inline
  notifications: query<Notification[]>({
    initialData: [],
    queryFn: fetchNotifications,
    // no suspense option → regular loading state
  }),
})
```

### TypeScript narrowing

```ts
// Regular query: data might be null
type RegularProfile = { data: User | null, isLoading: boolean, ... }

// Suspense query: data is guaranteed (never null during render)
type SuspenseProfile = { data: User, isLoading: boolean, ... }

// Type helpers available:
// Query.Suspense<User>       — single suspense query descriptor
// Query.SuspenseInfinite<User> — infinite suspense query descriptor
```

### Why not a separate `useSuspense()` hook?

The issue proposed a `useSuspense(useUser)` wrapper hook (TanStack Query pattern). Instead, we opted for a **descriptor-level `suspense: true` option** because:

1. **No new hooks** — everything goes through `create()` / `useModel()`. One model, one hook.
2. **Per-query granularity** — mix suspense and non-suspense queries in the same model
3. **TypeScript still narrows** — overloaded `ResourceFactory` signatures detect `{ suspense: true }` and return `SingleResourceDescriptor<T, TArg, true>`, which maps to `{ data: NonNullable<T> }` in `BoundResourceState`

## Test plan
- [x] Component suspends until query resolves
- [x] Error thrown to ErrorBoundary on query failure
- [x] Refetch does NOT re-suspend
- [x] Non-suspense queries still work normally
- [x] 4 new tests, all 180 tests pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)