### PR TITLE
fix(proxy): prevent TypeError on repeated query() calls

### DIFF
--- a/apps/docs/content/blog/v0.2.1-release.mdx
+++ b/apps/docs/content/blog/v0.2.1-release.mdx
@@ -1,0 +1,34 @@
+---
+title: 'comwit v0.2.1 — Fix repeated query() TypeError'
+date: '2026-02-21'
+description: 'v0.2.1 patch release. Fixes TypeError on repeated query() calls when data contains arrays or nested objects.'
+author: 'Claude Code'
+---
+
+## Bug Fix
+
+### `query().query()` no longer throws on second call ([#35](https://github.com/meursyphus/comwit/issues/35))
+
+Calling `.query()` on a resource field worked fine the first time, but threw a `TypeError` on any subsequent call:
+
+```
+TypeError: Cannot assign to read only property '0' of object '[object Array]'
+```
+
+**Root cause:** When comwit caches query results internally, it deep-freezes the snapshot via `Object.freeze`. On the next `.query()` call, the cached (frozen) state was restored into the reactive proxy — but the proxy's `wrap()` function tried to mutate the frozen array in-place to set up reactivity, causing the TypeError.
+
+**Fix:** The proxy engine now shallow-clones any frozen object before wrapping it, so frozen snapshots from the cache are never mutated directly. ([PR #36](https://github.com/meursyphus/comwit/pull/36))
+
+This affected any `query()` field where `data` was an array or nested object — which is virtually every real-world use case.
+
+---
+
+## Upgrade
+
+```bash
+yarn add comwit@0.2.1
+```
+
+Drop-in replacement. No API changes.
+
+[GitHub Release](https://github.com/meursyphus/comwit/releases/tag/v0.2.1) | [npm](https://www.npmjs.com/package/comwit/v/0.2.1)

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "homepage": "https://comwit.io",
   "repository": {

--- a/packages/comwit/src/core/proxy.ts
+++ b/packages/comwit/src/core/proxy.ts
@@ -37,6 +37,10 @@ export function createProxy<T extends object>(initialValue: T): T {
   function wrap(obj: any): any {
     if (!canProxy(obj)) return obj
 
+    if (Object.isFrozen(obj)) {
+      obj = Array.isArray(obj) ? [...obj] : { ...obj }
+    }
+
     if (Array.isArray(obj)) {
       for (let i = 0; i < obj.length; i++) {
         if (canProxy(obj[i])) obj[i] = wrap(obj[i])

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -454,4 +454,41 @@ describe('query', () => {
       expect(bound.data).toBe('second')
     })
   })
+
+  describe('Frozen state regression (#35)', () => {
+    it('should not throw on second query() call when data is an array', async () => {
+      let callCount = 0
+      const bound = createBound({
+        initialData: [] as string[],
+        queryFn: vi.fn().mockImplementation(() => {
+          callCount++
+          return Promise.resolve([`item-${callCount}`])
+        }),
+      })
+
+      await bound.query()
+      expect(bound.data).toEqual(['item-1'])
+
+      // Second call should NOT throw "Cannot assign to read only property"
+      await bound.query({ force: true })
+      expect(bound.data).toEqual(['item-2'])
+    })
+
+    it('should not throw on second query() call when data is a nested object', async () => {
+      let callCount = 0
+      const bound = createBound({
+        initialData: { items: [] as string[], total: 0 },
+        queryFn: vi.fn().mockImplementation(() => {
+          callCount++
+          return Promise.resolve({ data: { items: [`item-${callCount}`], total: callCount } })
+        }),
+      })
+
+      await bound.query()
+      expect(bound.data).toEqual({ items: ['item-1'], total: 1 })
+
+      await bound.query({ force: true })
+      expect(bound.data).toEqual({ items: ['item-2'], total: 2 })
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- `query().query()` threw `TypeError: Cannot assign to read only property '0'` on second call because `wrap()` in proxy.ts tried to mutate frozen arrays/objects from `snapshot()` cache in-place
- Fixed by shallow-cloning frozen objects before wrapping them in the reactive proxy
- Added regression tests for array and nested object query data

Fixes #35

## Test plan
- [x] Added test: second `query({ force: true })` call with array data does not throw
- [x] Added test: second `query({ force: true })` call with nested object data does not throw
- [x] All 209 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)