### PR TITLE
feat: add model lifecycle hooks (onObserve/cleanup)

### DIFF
--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -14,6 +14,7 @@ export type StoreEntry<T extends object = any> = {
 export type ModelOptions<T extends object, D extends object = {}> = {
   derive?: (state: T) => { [K in keyof D]: () => D[K] }
   rules?: { [K in keyof T]?: (value: T[K]) => true | string }
+  onObserve?: (state: T) => void | (() => void)
 }
 
 export type ValidationState<T> = {
@@ -43,6 +44,7 @@ export function model<T extends object, D extends object = {}>(
   const m: Model<T & Readonly<D>> = {
     key: Symbol(),
     pluginBags,
+    onObserve: options?.onObserve as Model<T & Readonly<D>>['onObserve'],
     instance(): StoreEntry<T & Readonly<D>> {
       const p = createProxy(cloneState())
 
@@ -137,6 +139,7 @@ function computeValidation<T extends object>(
 export type Model<T extends object> = {
   key: symbol
   pluginBags: Map<string, PluginBag>
+  onObserve?: (state: T) => void | (() => void)
   instance(): StoreEntry<T>
 }
 
@@ -148,7 +151,27 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
 
   const prevRef = useRef<unknown>(null)
 
-  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store])
+  const lifecycle = registry.getLifecycle(m)
+
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      lifecycle.subscriberCount++
+      if (lifecycle.subscriberCount === 1 && m.onObserve) {
+        const result = m.onObserve(store.proxy)
+        lifecycle.cleanup = typeof result === 'function' ? result : null
+      }
+      const unsubProxy = store.subscribe(listener)
+      return () => {
+        unsubProxy()
+        lifecycle.subscriberCount--
+        if (lifecycle.subscriberCount === 0 && lifecycle.cleanup) {
+          lifecycle.cleanup()
+          lifecycle.cleanup = null
+        }
+      }
+    },
+    [store, lifecycle, m]
+  )
 
   const getSnapshot = () => {
     const raw = store.getSnapshot()

--- a/packages/comwit/src/core/provider.tsx
+++ b/packages/comwit/src/core/provider.tsx
@@ -14,8 +14,14 @@ export type ComwitProviderProps = {
   defaultOptions?: RegistryDefaults
 }
 
+export type LifecycleState = {
+  subscriberCount: number
+  cleanup: (() => void) | null
+}
+
 export type StoreRegistry = {
   get<T extends object>(model: Model<T>): StoreEntry<T>
+  getLifecycle(model: Model<any>): LifecycleState
   context?: Record<string, unknown>
   pluginStates: Map<string, unknown>
   pluginDefaults: Map<string, unknown>
@@ -34,6 +40,7 @@ export function ComwitProvider({ children, defaultOptions, context = {} }: Comwi
   const registryRef = useRef<
     StoreRegistry & {
       stores: Map<symbol, StoreEntry>
+      lifecycles: Map<symbol, LifecycleState>
       context: Record<string, unknown>
     }
   >(null!)
@@ -52,6 +59,7 @@ export function ComwitProvider({ children, defaultOptions, context = {} }: Comwi
     registryRef.current = {
       context: {},
       stores: new Map(),
+      lifecycles: new Map(),
       pluginStates,
       pluginDefaults,
       get<T extends object>(model: Model<T>): StoreEntry<T> {
@@ -61,6 +69,13 @@ export function ComwitProvider({ children, defaultOptions, context = {} }: Comwi
         const entry = model.instance()
         registryRef.current.stores.set(model.key, entry)
         return entry as StoreEntry<T>
+      },
+      getLifecycle(model: Model<any>): LifecycleState {
+        const existing = registryRef.current.lifecycles.get(model.key)
+        if (existing) return existing
+        const state: LifecycleState = { subscriberCount: 0, cleanup: null }
+        registryRef.current.lifecycles.set(model.key, state)
+        return state
       },
     }
   }

--- a/packages/comwit/tests/lifecycle.test.tsx
+++ b/packages/comwit/tests/lifecycle.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment happy-dom
+import { describe, test, expect, vi } from 'vitest'
+import React from 'react'
+import { render, renderHook, act } from '@testing-library/react'
+import { model, useModel, ComwitProvider } from '../src'
+
+function createWrapper(providerProps: Record<string, any> = {}) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ComwitProvider {...providerProps}>{children}</ComwitProvider>
+  }
+}
+
+describe('model lifecycle hooks', () => {
+  test('onObserve fires on first subscription', () => {
+    const onObserve = vi.fn()
+    const counter = model({ count: 0 }, { onObserve })
+    const wrapper = createWrapper()
+
+    renderHook(() => useModel(counter), { wrapper })
+
+    expect(onObserve).toHaveBeenCalledTimes(1)
+  })
+
+  test('cleanup fires when all subscribers unmount', () => {
+    const cleanup = vi.fn()
+    const onObserve = vi.fn(() => cleanup)
+    const counter = model({ count: 0 }, { onObserve })
+    const wrapper = createWrapper()
+
+    const { unmount } = renderHook(() => useModel(counter), { wrapper })
+    expect(cleanup).not.toHaveBeenCalled()
+
+    unmount()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('onObserve does not fire on subsequent subscriptions (only 0→1)', () => {
+    const onObserve = vi.fn()
+    const counter = model({ count: 0 }, { onObserve })
+
+    function Subscriber() {
+      useModel(counter)
+      return null
+    }
+
+    const { rerender } = render(
+      <ComwitProvider>
+        <Subscriber />
+      </ComwitProvider>
+    )
+    expect(onObserve).toHaveBeenCalledTimes(1)
+
+    // Add second subscriber — should not fire again
+    rerender(
+      <ComwitProvider>
+        <Subscriber />
+        <Subscriber />
+      </ComwitProvider>
+    )
+    expect(onObserve).toHaveBeenCalledTimes(1)
+  })
+
+  test('cleanup fires only when last subscriber unmounts', () => {
+    const cleanup = vi.fn()
+    const onObserve = vi.fn(() => cleanup)
+    const counter = model({ count: 0 }, { onObserve })
+
+    function Subscriber() {
+      useModel(counter)
+      return null
+    }
+
+    const { rerender, unmount } = render(
+      <ComwitProvider>
+        <Subscriber />
+        <Subscriber />
+      </ComwitProvider>
+    )
+
+    // Remove one subscriber — cleanup should not fire yet
+    rerender(
+      <ComwitProvider>
+        <Subscriber />
+      </ComwitProvider>
+    )
+    expect(cleanup).not.toHaveBeenCalled()
+
+    // Remove all subscribers
+    unmount()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  test('multiple subscribe/unsubscribe cycles', () => {
+    const cleanup = vi.fn()
+    const onObserve = vi.fn(() => cleanup)
+    const counter = model({ count: 0 }, { onObserve })
+    const wrapper = createWrapper()
+
+    // First cycle
+    const { unmount: unmount1 } = renderHook(() => useModel(counter), { wrapper })
+    expect(onObserve).toHaveBeenCalledTimes(1)
+    unmount1()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+
+    // Second cycle — should fire again
+    const { unmount: unmount2 } = renderHook(() => useModel(counter), { wrapper })
+    expect(onObserve).toHaveBeenCalledTimes(2)
+    unmount2()
+    expect(cleanup).toHaveBeenCalledTimes(2)
+  })
+
+  test('onObserve receives proxy state (mutations work)', async () => {
+    let capturedState: { count: number } | null = null
+    const counter = model(
+      { count: 0 },
+      {
+        onObserve(state) {
+          capturedState = state
+          state.count = 42
+        },
+      }
+    )
+    const wrapper = createWrapper()
+
+    const { result } = renderHook(() => useModel(counter), { wrapper })
+
+    expect(capturedState).not.toBeNull()
+    // The proxy mutation should propagate
+    await act(async () => {})
+    expect(result.current.count).toBe(42)
+  })
+
+  test('per-provider isolation', () => {
+    const onObserve = vi.fn()
+    const counter = model({ count: 0 }, { onObserve })
+
+    const wrapper1 = createWrapper()
+    const wrapper2 = createWrapper()
+
+    renderHook(() => useModel(counter), { wrapper: wrapper1 })
+    expect(onObserve).toHaveBeenCalledTimes(1)
+
+    renderHook(() => useModel(counter), { wrapper: wrapper2 })
+    expect(onObserve).toHaveBeenCalledTimes(2)
+  })
+
+  test('works with multiple models', () => {
+    const onObserveA = vi.fn()
+    const onObserveB = vi.fn()
+    const modelA = model({ a: 1 }, { onObserve: onObserveA })
+    const modelB = model({ b: 2 }, { onObserve: onObserveB })
+    const wrapper = createWrapper()
+
+    renderHook(
+      () => {
+        useModel(modelA)
+        useModel(modelB)
+      },
+      { wrapper }
+    )
+
+    expect(onObserveA).toHaveBeenCalledTimes(1)
+    expect(onObserveB).toHaveBeenCalledTimes(1)
+  })
+
+  test('model without onObserve works normally', () => {
+    const counter = model({ count: 0 })
+    const wrapper = createWrapper()
+
+    const { result } = renderHook(() => useModel(counter), { wrapper })
+    expect(result.current.count).toBe(0)
+  })
+
+  test('onObserve with no cleanup return works', () => {
+    const onObserve = vi.fn() // returns undefined
+    const counter = model({ count: 0 }, { onObserve })
+    const wrapper = createWrapper()
+
+    const { unmount } = renderHook(() => useModel(counter), { wrapper })
+    expect(onObserve).toHaveBeenCalledTimes(1)
+
+    // Should not throw when unmounting without cleanup
+    unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `onObserve` option to `model()` that fires when the first subscriber mounts (0→1 transition)
- The `onObserve` callback can return a cleanup function that fires when the last subscriber unmounts (1→0 transition)
- Lifecycle state is tracked per-provider instance via `LifecycleState` in the registry

## Usage

### Managing WebSocket Connections

Keep a WebSocket open only while components are subscribed to the model:

```ts
import { model } from 'comwit';

const PriceModel = model({
  symbol: 'AAPL',
  price: 0,
  lastUpdated: null as Date | null,
}, {
  onObserve(state) {
    // Opens WebSocket when the first component subscribes
    const ws = new WebSocket(`wss://prices.example.com/${state.symbol}`);
    ws.onmessage = (e) => {
      state.price = JSON.parse(e.data).price;
      state.lastUpdated = new Date();
    };

    // Cleanup: closes when the last component unmounts
    return () => ws.close();
  },
});
```

### Polling Interval

```ts
const NotificationModel = model({
  items: [] as Notification[],
  unreadCount: 0,
}, {
  onObserve(state) {
    // Poll every 30s only while the model is observed
    const interval = setInterval(async () => {
      const res = await fetch('/api/notifications');
      const data = await res.json();
      state.items = data.items;
      state.unreadCount = data.unreadCount;
    }, 30_000);

    return () => clearInterval(interval);
  },
});
```

### In Components (unchanged API)

```tsx
function PriceTicker() {
  // Subscribing via useModel triggers onObserve automatically
  const price = useModel(PriceModel, s => s.price);
  return <span>${price}</span>;
}
// When this component unmounts and no other subscribers remain, cleanup runs
```

## Test plan
- [x] onObserve fires on first subscription
- [x] Cleanup fires when all subscribers unmount
- [x] No firing on subsequent subscriptions (only 0→1)
- [x] Multiple subscribe/unsubscribe cycles
- [x] onObserve receives proxy state (mutations work)
- [x] Per-provider isolation
- [x] Works with multiple models
- [x] All 209 existing tests still pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)