### PR TITLE
feat: remove valtio dependency, inline proxy reactivity engine

### DIFF
--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -74,7 +74,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "es-toolkit": "^1.44.0",
-    "valtio": "^2.3.0"
+    "es-toolkit": "^1.44.0"
   }
 }

--- a/packages/comwit/src/core/proxy.ts
+++ b/packages/comwit/src/core/proxy.ts
@@ -1,81 +1,250 @@
-import {
-  proxy as valtioProxy,
-  snapshot as valtioSnapshot,
-  subscribe as valtioSubscribe,
-  ref,
-} from 'valtio'
+// Proxy-based reactivity engine
+// Based on valtio (https://github.com/pmndrs/valtio) — MIT License
+// Stripped of proxy-compare dependency, with built-in native-object exclusion
 
-const realProxyMap = new WeakMap<object, object>()
+const isObject = (x: unknown): x is object => typeof x === 'object' && x !== null
 
-function needsRef(value: unknown): boolean {
-  if (value === null || typeof value !== 'object') return false
-  const proto = Object.getPrototypeOf(value)
-  if (proto === Object.prototype || proto === null || Array.isArray(value)) return false
-  return true
+type Path = (string | symbol)[]
+type Op =
+  | [op: 'set', path: Path, value: unknown, prevValue: unknown]
+  | [op: 'delete', path: Path, prevValue: unknown]
+type Listener = (op: Op | undefined, nextVersion: number) => void
+type RemoveListener = () => void
+type AddListener = (listener: Listener) => RemoveListener
+type ProxyState = readonly [
+  target: object,
+  ensureVersion: (nextCheckVersion?: number) => number,
+  addListener: AddListener,
+]
+
+// --- internal state ---
+const proxyStateMap = new WeakMap<object, ProxyState>()
+const refSet = new WeakSet<object>()
+const snapCache = new WeakMap<object, [version: number, snap: unknown]>()
+const versionHolder = [1] as [number]
+const proxyCache = new WeakMap<object, object>()
+
+// --- canProxy: only plain objects and arrays ---
+function canProxy(x: unknown): boolean {
+  if (!isObject(x) || refSet.has(x)) return false
+  if (Array.isArray(x)) return true
+  const proto = Object.getPrototypeOf(x)
+  // Only proxy plain objects (prototype is Object.prototype or null)
+  return proto === Object.prototype || proto === null
 }
 
-function autoRefDeep(obj: any): void {
-  if (Array.isArray(obj)) {
-    for (let i = 0; i < obj.length; i++) {
-      if (needsRef(obj[i])) obj[i] = ref(obj[i])
-      else if (obj[i] !== null && typeof obj[i] === 'object') autoRefDeep(obj[i])
+// --- snapshot ---
+function createSnapshot<T extends object>(target: T, version: number): T {
+  const cache = snapCache.get(target)
+  if (cache?.[0] === version) {
+    return cache[1] as T
+  }
+  const snap: any = Array.isArray(target) ? [] : Object.create(Object.getPrototypeOf(target))
+  snapCache.set(target, [version, snap])
+  Reflect.ownKeys(target).forEach((key) => {
+    if (Object.getOwnPropertyDescriptor(snap, key)) {
+      return
     }
-  } else {
-    for (const key of Object.keys(obj)) {
-      if (needsRef(obj[key])) obj[key] = ref(obj[key])
-      else if (obj[key] !== null && typeof obj[key] === 'object') autoRefDeep(obj[key])
+    const value = Reflect.get(target, key)
+    const { enumerable } = Reflect.getOwnPropertyDescriptor(target, key) as PropertyDescriptor
+    const desc: PropertyDescriptor = {
+      value,
+      enumerable: enumerable as boolean,
+      configurable: true,
     }
+    if (proxyStateMap.has(value as object)) {
+      const [target, ensureVersion] = proxyStateMap.get(value as object) as ProxyState
+      desc.value = createSnapshot(target, ensureVersion())
+    }
+    Object.defineProperty(snap, key, desc)
+  })
+  return Object.preventExtensions(snap)
+}
+
+// --- handler ---
+function createHandler<T extends object>(
+  isInitializing: () => boolean,
+  addPropListener: (prop: string | symbol, propValue: unknown) => void,
+  removePropListener: (prop: string | symbol) => void,
+  notifyUpdate: (op: Op | undefined) => void
+): ProxyHandler<T> {
+  return {
+    deleteProperty(target: T, prop: string | symbol) {
+      const prevValue = Reflect.get(target, prop)
+      removePropListener(prop)
+      const deleted = Reflect.deleteProperty(target, prop)
+      if (deleted) {
+        notifyUpdate(['delete', [prop], prevValue])
+      }
+      return deleted
+    },
+    set(target: T, prop: string | symbol, value: any, receiver: object) {
+      const hasPrevValue = !isInitializing() && Reflect.has(target, prop)
+      const prevValue = Reflect.get(target, prop, receiver)
+      if (
+        hasPrevValue &&
+        (Object.is(prevValue, value) ||
+          (proxyCache.has(value) && Object.is(prevValue, proxyCache.get(value))))
+      ) {
+        return true
+      }
+      removePropListener(prop)
+      const nextValue = !proxyStateMap.has(value) && canProxy(value) ? proxyInner(value) : value
+      addPropListener(prop, nextValue)
+      Reflect.set(target, prop, nextValue, receiver)
+      notifyUpdate(['set', [prop], value, prevValue])
+      return true
+    },
   }
 }
 
-const wrapCache = new WeakMap<object, object>()
-
-function wrapWithAutoRef(target: any): any {
-  if (wrapCache.has(target)) return wrapCache.get(target)
-
-  const wrapped = new Proxy(target, {
-    get(t, prop) {
-      const value = Reflect.get(t, prop)
-      if (
-        typeof prop === 'string' &&
-        value !== null &&
-        typeof value === 'object' &&
-        !needsRef(value)
-      ) {
-        return wrapWithAutoRef(value)
+// --- proxy core ---
+function proxyInner<T extends object>(baseObject: T): T {
+  if (!isObject(baseObject)) {
+    throw new Error('object required')
+  }
+  const found = proxyCache.get(baseObject) as T | undefined
+  if (found) {
+    return found
+  }
+  let version = versionHolder[0]
+  const listeners = new Set<Listener>()
+  const notifyUpdate = (op: Op | undefined, nextVersion = ++versionHolder[0]) => {
+    if (version !== nextVersion) {
+      checkVersion = version = nextVersion
+      listeners.forEach((listener) => listener(op, nextVersion))
+    }
+  }
+  let checkVersion = version
+  const ensureVersion = (nextCheckVersion = versionHolder[0]) => {
+    if (checkVersion !== nextCheckVersion) {
+      checkVersion = nextCheckVersion
+      propProxyStates.forEach(([propProxyState]) => {
+        const propVersion = propProxyState[1](nextCheckVersion)
+        if (propVersion > version) {
+          version = propVersion
+        }
+      })
+    }
+    return version
+  }
+  const createPropListener =
+    (prop: string | symbol): Listener =>
+    (op, nextVersion) => {
+      let newOp: Op | undefined
+      if (op) {
+        newOp = [...op]
+        newOp[1] = [prop, ...(newOp[1] as Path)]
       }
-      return value
-    },
-    set(t, prop, value) {
-      if (needsRef(value)) {
-        value = ref(value)
-      } else if (value !== null && typeof value === 'object') {
-        autoRefDeep(value)
+      notifyUpdate(newOp, nextVersion)
+    }
+  const propProxyStates = new Map<string | symbol, readonly [ProxyState, RemoveListener?]>()
+  const addPropListener = (prop: string | symbol, propValue: unknown) => {
+    const propProxyState =
+      !refSet.has(propValue as object) && proxyStateMap.get(propValue as object)
+    if (propProxyState) {
+      if (listeners.size) {
+        const remove = propProxyState[2](createPropListener(prop))
+        propProxyStates.set(prop, [propProxyState, remove])
+      } else {
+        propProxyStates.set(prop, [propProxyState])
       }
-      return Reflect.set(t, prop, value)
-    },
-    deleteProperty(t, prop) {
-      return Reflect.deleteProperty(t, prop)
-    },
+    }
+  }
+  const removePropListener = (prop: string | symbol) => {
+    const entry = propProxyStates.get(prop)
+    if (entry) {
+      propProxyStates.delete(prop)
+      entry[1]?.()
+    }
+  }
+  const addListener = (listener: Listener) => {
+    listeners.add(listener)
+    if (listeners.size === 1) {
+      propProxyStates.forEach(([propProxyState, prevRemove], prop) => {
+        if (prevRemove) {
+          return
+        }
+        const remove = propProxyState[2](createPropListener(prop))
+        propProxyStates.set(prop, [propProxyState, remove])
+      })
+    }
+    const removeListener = () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) {
+        propProxyStates.forEach(([propProxyState, remove], prop) => {
+          if (remove) {
+            remove()
+            propProxyStates.set(prop, [propProxyState])
+          }
+        })
+      }
+    }
+    return removeListener
+  }
+  let initializing = true
+  const handler = createHandler<T>(
+    () => initializing,
+    addPropListener,
+    removePropListener,
+    notifyUpdate
+  )
+  const proxyObject = new Proxy(baseObject, handler)
+  proxyCache.set(baseObject, proxyObject)
+  const proxyState: ProxyState = [baseObject, ensureVersion, addListener]
+  proxyStateMap.set(proxyObject, proxyState)
+  Reflect.ownKeys(baseObject).forEach((key) => {
+    const desc = Object.getOwnPropertyDescriptor(baseObject, key) as PropertyDescriptor
+    if ('value' in desc && desc.writable) {
+      proxyObject[key as keyof T] = baseObject[key as keyof T]
+    }
   })
-
-  wrapCache.set(target, wrapped)
-  realProxyMap.set(wrapped, target)
-  return wrapped
+  initializing = false
+  return proxyObject
 }
 
+// --- public API ---
+
 export function createProxy<T extends object>(initialValue: T): T {
-  autoRefDeep(initialValue)
-  const p = valtioProxy(initialValue)
-  return wrapWithAutoRef(p) as T
+  return proxyInner(initialValue)
 }
 
 export function snapshot<T extends object>(state: T): T {
-  const real = realProxyMap.get(state) || state
-  return valtioSnapshot(real) as T
+  const proxyState = proxyStateMap.get(state)
+  if (!proxyState) {
+    throw new Error('Please use proxy object')
+  }
+  const [target, ensureVersion] = proxyState
+  return createSnapshot(target, ensureVersion()) as T
 }
 
-export function subscribe<T extends object>(state: T, listener: () => void): () => void {
-  const real = realProxyMap.get(state) || state
-  return valtioSubscribe(real, listener)
+export function subscribe<T extends object>(state: T, callback: () => void): () => void {
+  const proxyState = proxyStateMap.get(state)
+  if (!proxyState) {
+    throw new Error('Please use proxy object')
+  }
+  let promise: Promise<void> | undefined
+  const addListener = proxyState[2]
+  let isListenerActive = false
+  const listener: Listener = () => {
+    if (!promise) {
+      promise = Promise.resolve().then(() => {
+        promise = undefined
+        if (isListenerActive) {
+          callback()
+        }
+      })
+    }
+  }
+  const removeListener = addListener(listener)
+  isListenerActive = true
+  return () => {
+    isListenerActive = false
+    removeListener()
+  }
+}
+
+export function ref<T extends object>(obj: T): T {
+  refSet.add(obj)
+  return obj
 }

--- a/packages/comwit/src/core/proxy.ts
+++ b/packages/comwit/src/core/proxy.ts
@@ -1,8 +1,15 @@
 // Proxy-based reactivity engine
 // Based on valtio (https://github.com/pmndrs/valtio) — MIT License
-// Stripped of proxy-compare dependency, with built-in native-object exclusion
+// Per-proxy state stored on objects via Symbols; fallback WeakMaps only for
+// non-extensible objects (e.g. frozen snapshots) which are inherently safe for SSR.
 
 const isObject = (x: unknown): x is object => typeof x === 'object' && x !== null
+
+// Internal symbols — replace module-level WeakMaps for extensible objects
+const $state = Symbol('proxyState') // ProxyState, accessible via get trap
+const $ref = Symbol('ref') // marks objects excluded from proxying
+const $snap = Symbol('snap') // snapshot cache on target
+const $proxy = Symbol('proxy') // cached proxy on base object
 
 type Path = (string | symbol)[]
 type Op =
@@ -17,34 +24,55 @@ type ProxyState = readonly [
   addListener: AddListener,
 ]
 
-// --- internal state ---
-const proxyStateMap = new WeakMap<object, ProxyState>()
-const refSet = new WeakSet<object>()
-const snapCache = new WeakMap<object, [version: number, snap: unknown]>()
-const versionHolder = [1] as [number]
-const proxyCache = new WeakMap<object, object>()
+// Monotonic counter — stateless across requests, safe for SSR
+let globalVersion = 1
 
-// --- canProxy: only plain objects and arrays ---
+// Fallback for non-extensible objects (frozen snapshots, sealed configs).
+// WeakMap keyed by object identity — no cross-request leakage.
+const sealedProxyCache = new WeakMap<object, object>()
+const sealedSnapCache = new WeakMap<object, [version: number, snap: unknown]>()
+
 function canProxy(x: unknown): boolean {
-  if (!isObject(x) || refSet.has(x)) return false
+  if (!isObject(x) || (x as any)[$ref]) return false
   if (Array.isArray(x)) return true
   const proto = Object.getPrototypeOf(x)
-  // Only proxy plain objects (prototype is Object.prototype or null)
   return proto === Object.prototype || proto === null
+}
+
+function getProxyState(value: unknown): ProxyState | undefined {
+  if (!isObject(value)) return undefined
+  return (value as any)[$state] as ProxyState | undefined
+}
+
+function defineHidden(obj: object, sym: symbol, value: unknown, writable = false): void {
+  if (Object.isExtensible(obj)) {
+    Object.defineProperty(obj, sym, { value, writable, configurable: true })
+  }
 }
 
 // --- snapshot ---
 function createSnapshot<T extends object>(target: T, version: number): T {
-  const cache = snapCache.get(target)
+  const extensible = Object.isExtensible(target)
+  const cache = extensible
+    ? ((target as any)[$snap] as [number, unknown] | undefined)
+    : sealedSnapCache.get(target)
   if (cache?.[0] === version) {
     return cache[1] as T
   }
   const snap: any = Array.isArray(target) ? [] : Object.create(Object.getPrototypeOf(target))
-  snapCache.set(target, [version, snap])
-  Reflect.ownKeys(target).forEach((key) => {
-    if (Object.getOwnPropertyDescriptor(snap, key)) {
-      return
+  const cacheEntry: [number, unknown] = [version, snap]
+  if (extensible) {
+    if ($snap in (target as any)) {
+      ;(target as any)[$snap] = cacheEntry
+    } else {
+      defineHidden(target, $snap, cacheEntry, true)
     }
+  } else {
+    sealedSnapCache.set(target, cacheEntry)
+  }
+  Reflect.ownKeys(target).forEach((key) => {
+    if (key === $snap || key === $proxy) return
+    if (Object.getOwnPropertyDescriptor(snap, key)) return
     const value = Reflect.get(target, key)
     const { enumerable } = Reflect.getOwnPropertyDescriptor(target, key) as PropertyDescriptor
     const desc: PropertyDescriptor = {
@@ -52,9 +80,10 @@ function createSnapshot<T extends object>(target: T, version: number): T {
       enumerable: enumerable as boolean,
       configurable: true,
     }
-    if (proxyStateMap.has(value as object)) {
-      const [target, ensureVersion] = proxyStateMap.get(value as object) as ProxyState
-      desc.value = createSnapshot(target, ensureVersion())
+    const childState = getProxyState(value)
+    if (childState) {
+      const [childTarget, childEnsureVersion] = childState
+      desc.value = createSnapshot(childTarget, childEnsureVersion())
     }
     Object.defineProperty(snap, key, desc)
   })
@@ -63,12 +92,17 @@ function createSnapshot<T extends object>(target: T, version: number): T {
 
 // --- handler ---
 function createHandler<T extends object>(
+  proxyState: ProxyState,
   isInitializing: () => boolean,
   addPropListener: (prop: string | symbol, propValue: unknown) => void,
   removePropListener: (prop: string | symbol) => void,
   notifyUpdate: (op: Op | undefined) => void
 ): ProxyHandler<T> {
   return {
+    get(target: T, prop: string | symbol, receiver: object) {
+      if (prop === $state) return proxyState
+      return Reflect.get(target, prop, receiver)
+    },
     deleteProperty(target: T, prop: string | symbol) {
       const prevValue = Reflect.get(target, prop)
       removePropListener(prop)
@@ -81,15 +115,15 @@ function createHandler<T extends object>(
     set(target: T, prop: string | symbol, value: any, receiver: object) {
       const hasPrevValue = !isInitializing() && Reflect.has(target, prop)
       const prevValue = Reflect.get(target, prop, receiver)
+      const cachedProxy = isObject(value) && getCachedProxy(value)
       if (
         hasPrevValue &&
-        (Object.is(prevValue, value) ||
-          (proxyCache.has(value) && Object.is(prevValue, proxyCache.get(value))))
+        (Object.is(prevValue, value) || (cachedProxy && Object.is(prevValue, cachedProxy)))
       ) {
         return true
       }
       removePropListener(prop)
-      const nextValue = !proxyStateMap.has(value) && canProxy(value) ? proxyInner(value) : value
+      const nextValue = !getProxyState(value) && canProxy(value) ? proxyInner(value) : value
       addPropListener(prop, nextValue)
       Reflect.set(target, prop, nextValue, receiver)
       notifyUpdate(['set', [prop], value, prevValue])
@@ -98,25 +132,32 @@ function createHandler<T extends object>(
   }
 }
 
+function getCachedProxy(obj: object): object | undefined {
+  if (Object.isExtensible(obj)) {
+    return (obj as any)[$proxy] as object | undefined
+  }
+  return sealedProxyCache.get(obj)
+}
+
 // --- proxy core ---
 function proxyInner<T extends object>(baseObject: T): T {
   if (!isObject(baseObject)) {
     throw new Error('object required')
   }
-  const found = proxyCache.get(baseObject) as T | undefined
+  const found = getCachedProxy(baseObject) as T | undefined
   if (found) {
     return found
   }
-  let version = versionHolder[0]
+  let version = globalVersion
   const listeners = new Set<Listener>()
-  const notifyUpdate = (op: Op | undefined, nextVersion = ++versionHolder[0]) => {
+  const notifyUpdate = (op: Op | undefined, nextVersion = ++globalVersion) => {
     if (version !== nextVersion) {
       checkVersion = version = nextVersion
       listeners.forEach((listener) => listener(op, nextVersion))
     }
   }
   let checkVersion = version
-  const ensureVersion = (nextCheckVersion = versionHolder[0]) => {
+  const ensureVersion = (nextCheckVersion = globalVersion) => {
     if (checkVersion !== nextCheckVersion) {
       checkVersion = nextCheckVersion
       propProxyStates.forEach(([propProxyState]) => {
@@ -140,8 +181,8 @@ function proxyInner<T extends object>(baseObject: T): T {
     }
   const propProxyStates = new Map<string | symbol, readonly [ProxyState, RemoveListener?]>()
   const addPropListener = (prop: string | symbol, propValue: unknown) => {
-    const propProxyState =
-      !refSet.has(propValue as object) && proxyStateMap.get(propValue as object)
+    if (isObject(propValue) && (propValue as any)[$ref]) return
+    const propProxyState = getProxyState(propValue)
     if (propProxyState) {
       if (listeners.size) {
         const remove = propProxyState[2](createPropListener(prop))
@@ -162,9 +203,7 @@ function proxyInner<T extends object>(baseObject: T): T {
     listeners.add(listener)
     if (listeners.size === 1) {
       propProxyStates.forEach(([propProxyState, prevRemove], prop) => {
-        if (prevRemove) {
-          return
-        }
+        if (prevRemove) return
         const remove = propProxyState[2](createPropListener(prop))
         propProxyStates.set(prop, [propProxyState, remove])
       })
@@ -182,18 +221,23 @@ function proxyInner<T extends object>(baseObject: T): T {
     }
     return removeListener
   }
+  const proxyState: ProxyState = [baseObject, ensureVersion, addListener]
   let initializing = true
   const handler = createHandler<T>(
+    proxyState,
     () => initializing,
     addPropListener,
     removePropListener,
     notifyUpdate
   )
   const proxyObject = new Proxy(baseObject, handler)
-  proxyCache.set(baseObject, proxyObject)
-  const proxyState: ProxyState = [baseObject, ensureVersion, addListener]
-  proxyStateMap.set(proxyObject, proxyState)
+  if (Object.isExtensible(baseObject)) {
+    defineHidden(baseObject, $proxy, proxyObject)
+  } else {
+    sealedProxyCache.set(baseObject, proxyObject)
+  }
   Reflect.ownKeys(baseObject).forEach((key) => {
+    if (key === $proxy) return
     const desc = Object.getOwnPropertyDescriptor(baseObject, key) as PropertyDescriptor
     if ('value' in desc && desc.writable) {
       proxyObject[key as keyof T] = baseObject[key as keyof T]
@@ -210,7 +254,7 @@ export function createProxy<T extends object>(initialValue: T): T {
 }
 
 export function snapshot<T extends object>(state: T): T {
-  const proxyState = proxyStateMap.get(state)
+  const proxyState = getProxyState(state)
   if (!proxyState) {
     throw new Error('Please use proxy object')
   }
@@ -219,7 +263,7 @@ export function snapshot<T extends object>(state: T): T {
 }
 
 export function subscribe<T extends object>(state: T, callback: () => void): () => void {
-  const proxyState = proxyStateMap.get(state)
+  const proxyState = getProxyState(state)
   if (!proxyState) {
     throw new Error('Please use proxy object')
   }
@@ -245,6 +289,6 @@ export function subscribe<T extends object>(state: T, callback: () => void): () 
 }
 
 export function ref<T extends object>(obj: T): T {
-  refSet.add(obj)
+  defineHidden(obj, $ref, true)
   return obj
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4896,11 +4896,6 @@ property-information@^7.0.0:
   resolved "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz"
   integrity sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
 
-proxy-compare@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-3.0.1.tgz#3262cff3a25a6dedeaa299f6cf2369d6f7588a94"
-  integrity sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==
-
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
@@ -5909,13 +5904,6 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-valtio@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-2.3.1.tgz#128992decd0952331c59d567e29efe526baebb35"
-  integrity sha512-ZsOaOEn0U9IJ96cAj3CZ3GjwpN3EJdjsi1PT4PREuB+Pcqfsczu16isT5DT1UrmHbk4PtLjk8kwNEHuR2CX56w==
-  dependencies:
-    proxy-compare "^3.0.1"
 
 vfile-matter@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
## Summary
- Removed `valtio` runtime dependency from `packages/comwit`
- Implemented proxy reactivity engine inline in `proxy.ts`, based on [valtio's source](https://github.com/pmndrs/valtio/blob/main/src/vanilla.ts) (MIT License)
- Eliminated `proxy-compare` dependency by integrating native-object exclusion directly into `canProxy()` — only plain objects and arrays are proxied, which naturally handles File, Blob, Date, Map, etc. without the previous `autoRefDeep`/`wrapWithAutoRef` wrapper layer
- `es-toolkit` is now the **sole** runtime dependency

## What changed
- `packages/comwit/src/core/proxy.ts`: Replaced valtio imports with ~220 lines of inline implementation covering `proxy()`, `snapshot()`, `subscribe()`, and `ref()`
- `packages/comwit/package.json`: Removed `valtio` from `dependencies`

## Test plan
- [x] All 232 tests pass (15 test files)
- [x] TypeScript typecheck passes
- [x] Vite build succeeds (ESM + CJS)
- [x] Proxy tests: reactivity, snapshots, subscriptions, batching, nested objects, arrays, native objects (File/Blob/Date/Map)

🤖 Generated with [Claude Code](https://claude.com/claude-code)