### PR TITLE
docs: add SWC decorator setup step to llms.txt

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -10,7 +10,23 @@ State management for Next.js.
 npm i comwit
 ```
 
-## 2. Setup Provider
+## 2. Enable Decorators
+
+Add `experimentalDecorators` to your `tsconfig.json`. Without this, Next.js production builds (SWC) will fail to parse `@OnError`, `@Retry`, etc.
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+    // ... other options
+  }
+}
+```
+
+> **Why?** Next.js reads this flag and passes it to SWC as `jsc.parser.decorators: true`. Without it, the `@` token is not recognized and the build fails with "Unexpected token '@'". Dev mode (Turbopack) may work without it, but production builds will not.
+
+## 3. Setup Provider
 
 Create `app/providers.tsx` and wrap your root layout.
 
@@ -63,11 +79,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-## 3. Create `state/.ai.md`
+## 4. Create `state/.ai.md`
 
 Create `src/state/.ai.md` (or `state/.ai.md`) with the full content below.
 
-## 4. Update `CLAUDE.md`
+## 5. Update `CLAUDE.md`
 
 Add this to your project's `CLAUDE.md`:
 


### PR DESCRIPTION
## Summary

Closes #57

- llms.txt 셋업 가이드에 `experimentalDecorators: true` 설정 단계 추가
- Next.js 프로덕션 빌드(SWC)에서 데코레이터 파싱 실패하는 근본 원인은 tsconfig.json 설정 누락
- SWC가 `jsc.parser.decorators: true`를 활성화하려면 tsconfig.json에 해당 플래그 필요

## Test plan

- [x] llms.txt 셋업 단계 번호 정합성 확인 (1→2→3→4→5)
- [x] 기존 컨텐츠 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)