### PR TITLE
fix: reset query state on arg change (React Query v5 semantics)

### DIFF
--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "homepage": "https://comwit.io",
   "repository": {

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -384,6 +384,15 @@ export function createResourceAccessor(
       applyCachedState(state, entry)
     }
 
+    // Determine if args changed (new cache entry, not a refetch)
+    const isArgChange = !isRefetch && !entry.hasQueried && activeEntryBefore?.hasQueried
+    const hasPlaceholderData = effectiveOptions.placeholderData !== undefined
+
+    // When args change and no placeholderData, reset to initial state
+    if (isArgChange && !hasPlaceholderData) {
+      Object.assign(state, descriptor.initialState)
+    }
+
     applyPlaceholderData(
       state as ResourceBaseState<unknown>,
       queryArg as never,
@@ -411,7 +420,14 @@ export function createResourceAccessor(
 
     state.isError = false
     state.error = null
-    state.isLoading = !state.isSuccess
+    // When args changed without placeholderData, this is a fresh load (isLoading=true)
+    // When args changed with placeholderData, previous data is kept (isLoading=false)
+    // When refetching same arg, data is kept (isLoading=false)
+    if (isArgChange && !hasPlaceholderData) {
+      state.isLoading = true
+    } else {
+      state.isLoading = !state.isSuccess
+    }
     state.isFetching = true
 
     // Track suspense promise for initial loads (not refetches)

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -455,6 +455,124 @@ describe('query', () => {
     })
   })
 
+  describe('Arg change reset behavior', () => {
+    it('Case 1: without keepPreviousData, changing arg resets data to initialData and sets isLoading=true', async () => {
+      const dA = deferred<string>()
+      const dB = deferred<string>()
+      const queryFn = vi.fn().mockReturnValueOnce(dA.promise).mockReturnValueOnce(dB.promise)
+
+      const bound = createBound({
+        initialData: 'init',
+        queryFn,
+      })
+
+      // query('a') succeeds
+      const promiseA = bound.query('a')
+      expect(bound.isLoading).toBe(true)
+      expect(bound.isFetching).toBe(true)
+      dA.resolve('resultA')
+      await promiseA
+      expect(bound.data).toBe('resultA')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isSuccess).toBe(true)
+
+      // query('b') called — data should reset to initialData, isLoading=true
+      const promiseB = bound.query('b')
+      expect(bound.data).toBe('init')
+      expect(bound.isLoading).toBe(true)
+      expect(bound.isFetching).toBe(true)
+      expect(bound.isSuccess).toBe(false)
+
+      dB.resolve('resultB')
+      await promiseB
+      expect(bound.data).toBe('resultB')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isSuccess).toBe(true)
+    })
+
+    it('Case 2: with keepPreviousData, changing arg keeps previous data and sets isFetching=true', async () => {
+      const dA = deferred<string>()
+      const dB = deferred<string>()
+      const queryFn = vi.fn().mockReturnValueOnce(dA.promise).mockReturnValueOnce(dB.promise)
+
+      const bound = createBound({
+        initialData: 'init',
+        queryFn,
+        placeholderData: keepPreviousData,
+      })
+
+      // query('a') succeeds
+      const promiseA = bound.query('a')
+      dA.resolve('resultA')
+      await promiseA
+      expect(bound.data).toBe('resultA')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isSuccess).toBe(true)
+
+      // query('b') called — previous data kept, isLoading=false, isFetching=true
+      const promiseB = bound.query('b')
+      expect(bound.data).toBe('resultA')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isFetching).toBe(true)
+
+      dB.resolve('resultB')
+      await promiseB
+      expect(bound.data).toBe('resultB')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isFetching).toBe(false)
+    })
+
+    it('Case 3: same arg refetch keeps data regardless of keepPreviousData', async () => {
+      const dRefetch = deferred<string>()
+      const queryFn = vi.fn().mockResolvedValueOnce('resultA').mockReturnValueOnce(dRefetch.promise)
+
+      const bound = createBound({
+        initialData: 'init',
+        queryFn,
+      })
+
+      // query('a') succeeds
+      await bound.query('a')
+      expect(bound.data).toBe('resultA')
+      expect(bound.isSuccess).toBe(true)
+
+      // refetch() — data stays, isLoading=false, isFetching=true
+      const refetchPromise = bound.refetch()
+      expect(bound.data).toBe('resultA')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isFetching).toBe(true)
+
+      dRefetch.resolve('resultA-refreshed')
+      await refetchPromise
+      expect(bound.data).toBe('resultA-refreshed')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isFetching).toBe(false)
+    })
+
+    it('Case 3 with keepPreviousData: same arg refetch keeps data', async () => {
+      const dRefetch = deferred<string>()
+      const queryFn = vi.fn().mockResolvedValueOnce('resultA').mockReturnValueOnce(dRefetch.promise)
+
+      const bound = createBound({
+        initialData: 'init',
+        queryFn,
+        placeholderData: keepPreviousData,
+      })
+
+      await bound.query('a')
+      expect(bound.data).toBe('resultA')
+
+      const refetchPromise = bound.refetch()
+      expect(bound.data).toBe('resultA')
+      expect(bound.isLoading).toBe(false)
+      expect(bound.isFetching).toBe(true)
+
+      dRefetch.resolve('resultA-refreshed')
+      await refetchPromise
+      expect(bound.data).toBe('resultA-refreshed')
+    })
+  })
+
   describe('Frozen state regression (#35)', () => {
     it('should not throw on second query() call when data is an array', async () => {
       let callCount = 0


### PR DESCRIPTION
## Summary
- When `query(arg)` is called with a different argument without `keepPreviousData`, data now resets to `initialData` and `isLoading` becomes `true` (previously data was stale and `isLoading` stayed `false`)
- With `keepPreviousData`, previous data is kept as placeholder and `isFetching=true`, `isLoading=false`
- Same-arg refetch behavior unchanged: data always kept regardless of `keepPreviousData`
- Bumps version to 0.3.2

## Test plan
- [x] Added 4 new tests covering all 3 cases (arg change without keepPreviousData, with keepPreviousData, same-arg refetch with and without keepPreviousData)
- [x] All 286 tests pass (282 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)