### PR TITLE
Clarify query staleTime precedence for same-arg re-query

### DIFF
--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -62,17 +62,19 @@ Once accessed via `state()` in an action, query fields expose these methods:
 
 Pass options at the query definition or globally via `ComwitProvider`:
 
-| Option            | Description                                                                    |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `staleTime`       | Time in ms before cached data is considered stale (default: 0)                 |
-| `cacheTime`       | Alias for gcTime                                                               |
-| `gcTime`          | Time in ms before unused cache entries are garbage collected                   |
-| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results. |
-| `force`           | Skip cache and always fetch (call-time only)                                   |
-| `enabled`         | `(state) => boolean` — skip query when condition is false                      |
-| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved             |
-| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval    |
-| `suspense`        | `boolean` — enable React Suspense integration                                  |
+| Option            | Description                                                                                              |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `staleTime`       | Time in ms before cached data is considered stale (default: `0`, unless overridden via `ComwitProvider`) |
+| `cacheTime`       | Alias for gcTime                                                                                         |
+| `gcTime`          | Time in ms before unused cache entries are garbage collected                                             |
+| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results.                           |
+| `force`           | Skip cache and always fetch (call-time only)                                                             |
+| `enabled`         | `(state) => boolean` — skip query when condition is false                                                |
+| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved                                       |
+| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval                              |
+| `suspense`        | `boolean` — enable React Suspense integration                                                            |
+
+Provider defaults are merged first. Per-query and call-time options override `ComwitProvider` defaults when you set them explicitly.
 
 ## queryFn context
 

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -28,10 +28,12 @@ export const post = model<PostState>({
 | `initialData`     | `TData`                                     | **Required.** Initial value before any fetch.                        |
 | `queryFn`         | `(arg, context) => TData \| Promise<TData>` | **Required.** Fetcher function.                                      |
 | `suspense`        | `boolean`                                   | Enable React Suspense integration. Default `false`.                  |
-| `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0`.    |
+| `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0` unless overridden by `ComwitProvider`. |
 | `cacheTime`       | `number`                                    | Alias for `gcTime`. Milliseconds before cache entry is garbage collected. |
 | `gcTime`          | `number`                                    | Milliseconds before cache entry is garbage collected.                |
 | `placeholderData` | `TData \| (arg, previousData) => TData`     | Data shown while fetching. Use `keepPreviousData` helper.            |
+
+Provider defaults are merged first. Per-query and call-time options override `ComwitProvider` defaults when set explicitly.
 
 ### queryFn Signature
 

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -23,6 +23,9 @@ function createBound<TData>(opts: {
   staleTime?: number
   gcTime?: number
   placeholderData?: any
+  defaults?: {
+    staleTime?: number
+  }
 }) {
   const m = model({
     resource: query({
@@ -38,7 +41,7 @@ function createBound<TData>(opts: {
   const bound = bindResourceState(
     store.proxy,
     m.pluginBags.get('query')!,
-    undefined,
+    opts.defaults,
     registry
   ) as any
   return bound.resource as BoundSingleResourceState<TData, any>
@@ -134,6 +137,24 @@ describe('query', () => {
   })
 
   describe('Cache', () => {
+    it('should call queryFn again on same arg when staleTime defaults to 0', async () => {
+      const queryFn = vi
+        .fn()
+        .mockImplementation((arg: { id: string; page: number }) =>
+          Promise.resolve([arg.id, arg.page])
+        )
+      const bound = createBound({
+        initialData: [] as Array<string | number>,
+        queryFn,
+        placeholderData: keepPreviousData,
+      })
+
+      await bound.query({ id: '123', page: 1 })
+      await bound.query({ id: '123', page: 1 })
+
+      expect(queryFn).toHaveBeenCalledTimes(2)
+    })
+
     it('should return cached result within staleTime without calling queryFn again', async () => {
       const queryFn = vi.fn().mockResolvedValue(['alice'])
       const bound = createBound({
@@ -234,6 +255,68 @@ describe('query', () => {
       expect(queryFn).toHaveBeenCalledTimes(3)
 
       vi.restoreAllMocks()
+    })
+
+    it('should respect provider default staleTime across rebinds with the same arg', async () => {
+      const queryFn = vi
+        .fn()
+        .mockImplementation((arg: { id: string; page: number }) =>
+          Promise.resolve([arg.id, arg.page])
+        )
+
+      const m = model({
+        resource: query({
+          initialData: [] as Array<string | number>,
+          queryFn,
+          placeholderData: keepPreviousData,
+        }),
+      })
+      const store = m.instance()
+      const registry = createQueryBindingRegistry()
+      const defaults = { staleTime: 60_000 }
+
+      const firstBind = bindResourceState(
+        store.proxy,
+        m.pluginBags.get('query')!,
+        defaults,
+        registry
+      ) as any
+
+      await firstBind.resource.query({ id: '123', page: 1 })
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      const rebound = bindResourceState(
+        store.proxy,
+        m.pluginBags.get('query')!,
+        defaults,
+        registry
+      ) as any
+
+      await rebound.resource.query({ id: '123', page: 1 })
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      await rebound.resource.query({ id: '123', page: 1 }, { force: true })
+      expect(queryFn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should let descriptor staleTime override provider default staleTime', async () => {
+      const queryFn = vi
+        .fn()
+        .mockImplementation((arg: { id: string; page: number }) =>
+          Promise.resolve([arg.id, arg.page])
+        )
+      const bound = createBound({
+        initialData: [] as Array<string | number>,
+        queryFn,
+        staleTime: 0,
+        placeholderData: keepPreviousData,
+        defaults: { staleTime: 60_000 },
+      })
+
+      await bound.query({ id: '123', page: 1 })
+      await bound.query({ id: '123', page: 1 })
+
+      expect(queryFn).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
## Summary
- add regression coverage confirming same-arg `query()` calls refetch when the effective `staleTime` is the default `0`
- add coverage showing provider-level `defaultOptions.query.staleTime` persists across rebinds/remounts and explains the reported cache hit behavior
- document that `ComwitProvider` defaults are merged first, and that explicit per-query/call-time options override them

## Validation
- `yarn workspace comwit test`

Closes #62