### PR TITLE
docs: add class-level lazy decorator example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /.next
 /pnpm-lock.yaml
 /yarn-error.log
+/.worktree

--- a/apps/docs/public/llm/decorator.txt
+++ b/apps/docs/public/llm/decorator.txt
@@ -336,7 +336,9 @@ class PostActions {
 
 ### Class-level Decorators
 
-Apply to all methods on a class:
+Apply to all methods on a class — works with both immediate and lazy mode.
+
+**Immediate mode** — no state access needed:
 
 ```ts
 @intercept({ onBefore: () => console.log('any method called') })
@@ -345,6 +347,36 @@ class Actions {
   doB() { ... }
 }
 ```
+
+**Lazy mode** — shares `state()`/`context` access across every method on the class. Useful when every action in a group has the same precondition (e.g. all mutations require login):
+
+```ts
+import { intercept } from 'comwit'
+import { user } from '@/state/user/model'
+
+const LoginRequired = intercept(({ state, context }) => {
+  const u = state(user)
+  return {
+    intercept: (execute, args) => {
+      if (!u.me) {
+        context.router.push('/login')
+        return
+      }
+      return execute(...args)
+    },
+  }
+})
+
+// applies to every method on the class — no need to repeat @LoginRequired per method
+@LoginRequired
+class PostCrudActions {
+  async create(title: string) { ... }
+  async update(id: string, title: string) { ... }
+  async delete(id: string) { ... }
+}
+```
+
+When class-level and method-level decorators coexist, both run — the method-level decorator wraps first, then the class-level decorator wraps the result.
 
 ## InterceptorHooks API
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -255,6 +255,14 @@ const LoginRequired = intercept<AppContext>(({ state, context }) => {
 @LoginRequired
 @OnSuccess(() => context.router.push('/posts'))
 async create(title: string) { /* ... */ }
+
+// or apply to the whole class — every method inherits the guard
+@LoginRequired
+class PostCrudActions {
+  async create(title: string) { /* ... */ }
+  async update(id: string, title: string) { /* ... */ }
+  async delete(id: string) { /* ... */ }
+}
 ```
 
 ```tsx


### PR DESCRIPTION
## Summary
- Class-level `intercept()` in lazy mode already works (covered by `interceptors-integration.test.tsx:203` and `interceptors.test.ts:720`), but the docs only showed the immediate-mode flavor for class-level usage.
- Added a `@LoginRequired` on a whole class example to both `llms.txt` and `decorator.txt` so readers know they can hoist a shared guard from per-method to per-class.
- Also noted method- and class-level decorators compose when both are present.

## Test plan
- [ ] Docs render correctly on the docs site
- [ ] No behavior change — docs-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)