### PR TITLE
feat(persist): allow PersistKey to be a thunk for runtime-derived keys

### DIFF
--- a/packages/comwit/src/core/persist.ts
+++ b/packages/comwit/src/core/persist.ts
@@ -12,8 +12,17 @@ export type PersistAdapter<T = unknown> = {
   subscribe?(key: string, callback: (value: T) => void): () => void
 }
 
+/**
+ * Persist key. Either a static string fixed at model-definition time, or a
+ * thunk evaluated each time the storage is touched (hydrate / write-back /
+ * cross-tab subscribe). The thunk form lets a single model field map to a
+ * runtime-derived key (e.g. per-route, per-project, per-tenant) without
+ * recreating the model.
+ */
+export type PersistKey = string | (() => string)
+
 export type PersistOptions<T> = {
-  key: string
+  key: PersistKey
   defaultValue: T
   storage?: 'localStorage' | 'sessionStorage' | PersistAdapter<T>
   serialize?: (value: T) => string
@@ -22,11 +31,15 @@ export type PersistOptions<T> = {
 
 export type PersistDescriptor<T = unknown> = {
   [PERSIST_BRAND]: true
-  key: string
+  key: PersistKey
   defaultValue: T
   adapter: PersistAdapter<T>
   serialize: (value: T) => string
   deserialize: (raw: string) => T
+}
+
+function resolveKey(key: PersistKey): string {
+  return typeof key === 'function' ? key() : key
 }
 
 export type PersistDefaults = {
@@ -166,8 +179,15 @@ export function bindPersistState(
     const { key, adapter, defaultValue } = descriptor
     const cleanups: Array<() => void> = []
 
+    // Resolve the key once at bind time for hydrate + cross-tab subscribe
+    // (the storage event listener can only register against a concrete key).
+    // Write-back also resolves it lazily — see below — so callers can change
+    // what the thunk returns later (e.g. when projectId becomes known) and
+    // subsequent writes will go to the new key.
+    const initialKey = resolveKey(key)
+
     // Hydrate from storage
-    const stored = adapter.get(key)
+    const stored = adapter.get(initialKey)
     silent(() => {
       if (stored !== null) {
         setNestedValue(proxy, path, stored)
@@ -176,10 +196,12 @@ export function bindPersistState(
       }
     })
 
-    // Subscribe to proxy changes and write back (debounced)
+    // Subscribe to proxy changes and write back (debounced).
+    // For dynamic keys, resolve at write time so writes follow the current
+    // identity (e.g. projectId switched between hydrate and a later mutation).
     const writeBack = debounce(() => {
       const currentValue = getNestedValue(proxy, path)
-      adapter.set(key, currentValue)
+      adapter.set(resolveKey(key), currentValue)
     }, debounceMs)
 
     const unsub = subscribe(proxy, () => {
@@ -188,9 +210,11 @@ export function bindPersistState(
     cleanups.push(unsub)
     cleanups.push(() => writeBack.cancel())
 
-    // Cross-tab sync
+    // Cross-tab sync — the storage event API is keyed by string, so we can
+    // only listen on a snapshot of the key. For dynamic keys this means
+    // cross-tab sync tracks whatever key was active at bind time.
     if (adapter.subscribe) {
-      const unsubStorage = adapter.subscribe(key, (newValue) => {
+      const unsubStorage = adapter.subscribe(initialKey, (newValue) => {
         silent(() => {
           setNestedValue(proxy, path, newValue)
         })

--- a/packages/comwit/tests/persist.test.ts
+++ b/packages/comwit/tests/persist.test.ts
@@ -147,6 +147,66 @@ describe('persist', () => {
     })
   })
 
+  describe('dynamic key (function form)', () => {
+    it('hydrates using the key returned by the thunk at bind time', () => {
+      const adapter = createMapAdapter<string>()
+      adapter.store.set('comwit-tabs-proj-A', 'persisted-A')
+      let projectId: string = 'proj-A'
+      const store = createPersisted({
+        key: () => `comwit-tabs-${projectId}`,
+        defaultValue: 'default',
+        storage: adapter,
+      })
+      expect(store.proxy.value).toBe('persisted-A')
+    })
+
+    it('falls back to defaultValue when the resolved key has no entry', () => {
+      const adapter = createMapAdapter<string>()
+      adapter.store.set('comwit-tabs-proj-A', 'persisted-A')
+      let projectId: string = 'proj-B'
+      const store = createPersisted({
+        key: () => `comwit-tabs-${projectId}`,
+        defaultValue: 'default',
+        storage: adapter,
+      })
+      expect(store.proxy.value).toBe('default')
+    })
+
+    it('writes back to the current key when the thunk return value changes', async () => {
+      const adapter = createMapAdapter<string>()
+      let projectId: string = 'proj-A'
+      const store = createPersisted({
+        key: () => `comwit-tabs-${projectId}`,
+        defaultValue: 'default',
+        storage: adapter,
+        debounceMs: 10,
+      })
+      // First write goes to proj-A
+      store.proxy.value = 'a-value'
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(adapter.store.get('comwit-tabs-proj-A')).toBe('a-value')
+
+      // Switch identity, write again — write must follow the new key
+      projectId = 'proj-B'
+      store.proxy.value = 'b-value'
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(adapter.store.get('comwit-tabs-proj-B')).toBe('b-value')
+      // proj-A row remains untouched
+      expect(adapter.store.get('comwit-tabs-proj-A')).toBe('a-value')
+    })
+
+    it('accepts a static string in the same field (backward compatible)', () => {
+      const adapter = createMapAdapter<string>()
+      adapter.store.set('static-key', 'persisted')
+      const store = createPersisted({
+        key: 'static-key',
+        defaultValue: 'default',
+        storage: adapter,
+      })
+      expect(store.proxy.value).toBe('persisted')
+    })
+  })
+
   describe('multiple persist fields', () => {
     it('handles multiple persist fields independently', () => {
       const nameAdapter = createMapAdapter<string>()


### PR DESCRIPTION
## Motivation

Models are evaluated at module load, so today's `persist({ key: string })` forces the storage identity to be **fixed before any runtime context is known** — route params, project ids, tenant ids, branch names. Apps that need a per-context key end up bypassing the plugin entirely and reaching for `window.localStorage` directly, which costs them every benefit `persist` is supposed to provide: debounced writes, automatic hydrate, cross-tab sync, custom adapters.

Concrete case that motivated this: a workspace app stores per-project preview-tab URLs. The page is `/projects/[projectId]/workspace`. The model can't be redefined per project, but the persisted blob has to be scoped per project so opening project A then B doesn't collide.

Today the workaround looks like this:

\`\`\`ts
// preview.ts — bypasses persist() entirely
const STORAGE_PREFIX = 'comwit-preview-tabs-'
let activeProjectId: string | null = null

function persistSnapshot(tabs, activeId) {
  if (!activeProjectId) return
  try {
    localStorage.setItem(
      \`\${STORAGE_PREFIX}\${activeProjectId}\`,
      JSON.stringify({ tabs, activeId }),
    )
  } catch {}
}
\`\`\`

…with manual hydrate, manual write triggers at the end of every action, manual cross-tab sync (none, in practice), and no debounce.

## Change

\`PersistKey\` becomes \`string | (() => string)\`.

- **Hydrate** resolves the thunk once at bind time.
- **Write-back** resolves it per call, so writes follow the current identity if the thunk closes over mutable state (e.g. \`projectId\` set after first paint).
- **Cross-tab subscribe** registers against the bind-time snapshot, since the \`storage\` event API can only listen on a concrete key. Documented as a known trade-off.
- Static-string usage is byte-for-byte unchanged. Existing models keep working.

## Usage

\`\`\`ts
let projectId: string

const m = model({
  previewTabs: persist({
    key: () => \`comwit-preview-tabs-\${projectId}\`,
    defaultValue: { tabs: [], activeId: '' },
  }),
})

// In the page mount, before the model is first read:
projectId = router.query.projectId
\`\`\`

That replaces ~60 lines of hand-rolled \`localStorage\` glue with the standard \`persist\` plumbing.

## Tests

Added under \`describe('dynamic key (function form)')\` in \`tests/persist.test.ts\`:

- hydrates from the key returned by the thunk at bind time
- falls back to \`defaultValue\` when the resolved key has no entry
- write-back follows the thunk's current return value (switch identity → next write goes to the new row, old row untouched)
- static-string form still works (backward-compatible path)

Full suite: 297/297 passing. Typecheck clean. Prettier clean on the touched files.

## Alternatives considered

1. **Context injection via Provider** — \`<ComwitProvider context={{ projectId }}>\` plus \`key: (ctx) => ...\`. Cleaner ergonomics and no closure-over-mutable-state, but it widens the surface across \`provider.tsx\`, \`plugin.ts\`, and the action context type, and forces a decision about how \`ctx\` changes propagate (rebind? error? silent?). Worth considering as a follow-up; not needed for the immediate use case.
2. **Imperative \`store.persist.rebind(field, key)\`** — explicit and small in surface, but every call site has to remember to call it on mount/route change, which is exactly the boilerplate this PR aims to remove.

The thunk form is the smallest change that lets the plugin replace existing hand-rolled workarounds without committing to a context model that may evolve later.

## Out of scope (intentionally)

- Re-binding on key change (cross-tab sync against a moving target).
- Doc site update — \`apps/docs/content/docs/api/persist.mdx\` failed prettier check on \`main\` already, so I left it alone to keep this PR's diff scoped. Happy to add a docs section in a follow-up or in this PR if preferred.