### PR TITLE
feat: add model history undo redo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /pnpm-lock.yaml
 /yarn-error.log
 /.worktree
+/.claude

--- a/apps/docs/content/docs/api/action.mdx
+++ b/apps/docs/content/docs/api/action.mdx
@@ -57,6 +57,8 @@ The factory receives `{ state, context }`:
 - **state(model)** — returns a mutable proxy to a model's state. Call it for each model you need.
 - **context** — the shared context from `ComwitProvider` (router, auth, etc.)
 
+When a model has [`history: true`](/docs/api/history), each action method call is recorded as one history transaction. Multiple state mutations inside the method are undone together via `state.$history.undo()`.
+
 ## Class pattern
 
 Use a class inside the factory. This gives you:

--- a/apps/docs/content/docs/api/history.mdx
+++ b/apps/docs/content/docs/api/history.mdx
@@ -93,8 +93,8 @@ const editor = model(
 ```
 
 - `history: false` or omitted — no `$history` field, no history tracking
-- `history: true` — enable history with no stack limit
-- `history: { limit }` — keep at most `limit` undo entries
+- `history: true` — enable history with the default limit of 100 undo entries
+- `history: { limit }` — enable history and override the undo stack limit
 
 ## Ignoring Changes
 

--- a/apps/docs/content/docs/api/history.mdx
+++ b/apps/docs/content/docs/api/history.mdx
@@ -1,0 +1,136 @@
+---
+title: '$history'
+group: 'API'
+slug: 'api/history'
+order: 8
+---
+
+# $history
+
+Undo and redo for model state. History is disabled by default and only exists on models that opt in.
+
+```ts
+import { model } from 'comwit'
+
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: true,
+  }
+)
+```
+
+## Usage
+
+No new hook is required. Read and call `$history` from the existing hook created by [`create()`](/docs/api/create).
+
+```tsx
+const { items, history } = useTodo((s) => ({
+  items: s.items,
+  history: s.$history,
+}))
+
+return (
+  <div>
+    <button onClick={() => history.undo()} disabled={!history.canUndo}>
+      Undo
+    </button>
+    <button onClick={() => history.redo()} disabled={!history.canRedo}>
+      Redo
+    </button>
+  </div>
+)
+```
+
+## Recording
+
+Each action method call is recorded as one history transaction.
+
+```ts
+const todoActions = action(({ state }) => ({
+  add(title: string) {
+    const s = state(todo)
+    s.items.push({ id: crypto.randomUUID(), title, done: false })
+    s.selectedId = s.items.at(-1)!.id
+  },
+}))
+```
+
+The two mutations above are undone together by one call to `s.$history.undo()`.
+
+## API
+
+```ts
+type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+```
+
+## Options
+
+```ts
+const editor = model(
+  { blocks: [] as Block[] },
+  {
+    history: {
+      limit: 100,
+    },
+  }
+)
+```
+
+- `history: false` or omitted — no `$history` field, no history tracking
+- `history: true` — enable history with no stack limit
+- `history: { limit }` — keep at most `limit` undo entries
+
+## Ignoring Changes
+
+Use `$history.ignore()` for state changes that should re-render but should not be undoable.
+
+```ts
+const editorActions = action(({ state }) => ({
+  setDraft(value: string) {
+    const s = state(editor)
+    s.$history.ignore(() => {
+      s.draft = value
+    })
+  },
+}))
+```
+
+This is different from [`silent()`](/docs/api/silent). `silent()` suppresses notifications for hydration-style writes. `$history.ignore()` only skips history recording.
+
+## Manual Transactions
+
+Action methods are already transactions. Use `$history.transaction()` only when you need to group nested or manual changes explicitly.
+
+```ts
+const editorActions = action(({ state }) => ({
+  bulkRename(ids: string[], title: string) {
+    const s = state(editor)
+    s.$history.transaction('bulk rename', () => {
+      for (const id of ids) {
+        const block = s.blocks.find((x) => x.id === id)
+        if (block) block.title = title
+      }
+    })
+  },
+}))
+```
+
+## Redo Stack
+
+When a new action is committed after an undo, the redo stack is cleared. This follows the standard undo/redo model used by editors and state history systems.

--- a/apps/docs/content/docs/api/model.mdx
+++ b/apps/docs/content/docs/api/model.mdx
@@ -50,6 +50,7 @@ export const app = model<AppState>({
 - Fields using [`query()`](/docs/api/query) become client-fetched data with loading states
 - Fields using [`persist()`](/docs/api/persist) are automatically synced to storage
 - Plain fields (strings, objects, arrays, null) are reactive local state
+- Models with `history: true` expose [`$history`](/docs/api/history) for undo and redo
 - Models initialize lazily — only when first accessed via a hook
 - Each model instance is scoped to the nearest `ComwitProvider`
 
@@ -152,6 +153,37 @@ const chat = model(
 - Initializing analytics or logging
 - Subscribing to external event sources
 
+## History
+
+History is disabled by default. Enable it per model when user-facing changes should support undo and redo.
+
+```ts
+const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: {
+      limit: 100,
+    },
+  }
+)
+```
+
+No new hook is needed. Access `$history` through the existing hook from [`create()`](/docs/api/create).
+
+```tsx
+const history = useTodo((s) => s.$history)
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+Each action method call is recorded as one transaction. Multiple mutations inside one action are undone together. Use `$history.ignore()` for changes that should re-render but should not be recorded.
+
 ## Options
 
 The second argument to `model()` accepts optional configuration:
@@ -161,6 +193,7 @@ model(initial, {
   derive?: (state) => ({ key: () => value }),
   rules?: { field: (value) => true | 'error message' },
   onObserve?: (state) => void | (() => void),
+  history?: boolean | { limit?: number },
 })
 ```
 

--- a/apps/docs/content/docs/api/model.mdx
+++ b/apps/docs/content/docs/api/model.mdx
@@ -171,6 +171,8 @@ const todo = model(
 )
 ```
 
+`history: true` uses a default limit of 100 undo entries. Pass `history: { limit }` to override the stack size.
+
 No new hook is needed. Access `$history` through the existing hook from [`create()`](/docs/api/create).
 
 ```tsx

--- a/apps/docs/content/docs/api/persist.mdx
+++ b/apps/docs/content/docs/api/persist.mdx
@@ -35,13 +35,13 @@ export type SettingsState = {
 
 ## Options
 
-| Option        | Type                                                    | Description                                        |
-| ------------- | ------------------------------------------------------- | -------------------------------------------------- |
-| `key`         | `string`                                                | **Required.** Storage key.                         |
-| `defaultValue`| `T`                                                     | **Required.** Value when storage is empty.         |
-| `storage`     | `'localStorage' \| 'sessionStorage' \| PersistAdapter`  | Storage backend. Default `'localStorage'`.         |
-| `serialize`   | `(value: T) => string`                                  | Custom serializer. Default `JSON.stringify`.       |
-| `deserialize` | `(raw: string) => T`                                    | Custom deserializer. Default `JSON.parse`.         |
+| Option         | Type                                                   | Description                                  |
+| -------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `key`          | `string`                                               | **Required.** Storage key.                   |
+| `defaultValue` | `T`                                                    | **Required.** Value when storage is empty.   |
+| `storage`      | `'localStorage' \| 'sessionStorage' \| PersistAdapter` | Storage backend. Default `'localStorage'`.   |
+| `serialize`    | `(value: T) => string`                                 | Custom serializer. Default `JSON.stringify`. |
+| `deserialize`  | `(raw: string) => T`                                   | Custom deserializer. Default `JSON.parse`.   |
 
 ## How it works
 
@@ -70,12 +70,20 @@ Implement `PersistAdapter<T>` for custom storage backends:
 import { type PersistAdapter } from 'comwit'
 
 const indexedDBAdapter: PersistAdapter<UserPrefs> = {
-  get(key) { /* read from IndexedDB */ },
-  set(key, value) { /* write to IndexedDB */ },
-  remove(key) { /* delete from IndexedDB */ },
+  get(key) {
+    /* read from IndexedDB */
+  },
+  set(key, value) {
+    /* write to IndexedDB */
+  },
+  remove(key) {
+    /* delete from IndexedDB */
+  },
   subscribe(key, callback) {
     // optional: listen for external changes
-    return () => { /* cleanup */ }
+    return () => {
+      /* cleanup */
+    }
   },
 }
 

--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -62,17 +62,16 @@ Once accessed via `state()` in an action, query fields expose these methods:
 
 Pass options at the query definition or globally via `ComwitProvider`:
 
-| Option            | Description                                                                    |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `staleTime`       | Time in ms before cached data is considered stale (default: 0)                 |
-| `cacheTime`       | Alias for gcTime                                                               |
-| `gcTime`          | Time in ms before unused cache entries are garbage collected                   |
-| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results. |
-| `force`           | Skip cache and always fetch (call-time only)                                   |
-| `enabled`         | `(state) => boolean` — skip query when condition is false                      |
-| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved             |
-| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval    |
-| `suspense`        | `boolean` — enable React Suspense integration                                  |
+| Option            | Description                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| `staleTime`       | Time in ms before cached data is considered stale (default: 0)                                   |
+| `gcTime`          | Time in ms a cache entry survives after the model loses its last observer (default: 5 \* 60_000) |
+| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results.                   |
+| `force`           | Skip cache and always fetch (call-time only)                                                     |
+| `enabled`         | `(state) => boolean` — skip query when condition is false                                        |
+| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved                               |
+| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval                      |
+| `suspense`        | `boolean` — enable React Suspense integration                                                    |
 
 ## queryFn context
 

--- a/apps/docs/content/docs/guide/quickstart.mdx
+++ b/apps/docs/content/docs/guide/quickstart.mdx
@@ -41,8 +41,7 @@ export function Providers({ children }: { children: ReactNode }) {
       defaultOptions={{
         query: {
           staleTime: 30_000,
-          cacheTime: 120_000,
-          gcTime: 180_000,
+          gcTime: 5 * 60_000,
           placeholderData: keepPreviousData,
         },
         persist: {
@@ -91,7 +90,7 @@ import { OnError, Log, ComwitProvider } from 'comwit'
 `ComwitProvider` takes two props:
 
 - **context** — shared values (router, auth, etc.) available in all actions
-- **defaultOptions.query** — global query defaults (staleTime, cacheTime, placeholderData)
+- **defaultOptions.query** — global query defaults (staleTime, gcTime, placeholderData)
 - **defaultOptions.persist** — global persist defaults (debounceMs)
 - **defaultOptions.interceptors** — global interceptors applied to all action methods
 

--- a/apps/docs/public/llm/history.txt
+++ b/apps/docs/public/llm/history.txt
@@ -1,0 +1,78 @@
+# comwit — History Reference
+
+History adds undo and redo to a model. It is disabled by default.
+
+## Enable
+
+```ts
+import { model } from 'comwit'
+
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: { limit: 100 },
+  }
+)
+```
+
+Use `history: true` for no limit.
+
+## Use
+
+No new hook is needed. Use the existing hook created by `create()`.
+
+```tsx
+const history = useTodo((s) => s.$history)
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+## Recording Model
+
+Each action method call is recorded as one transaction.
+
+```ts
+const todoActions = action(({ state }) => ({
+  add(title: string) {
+    const s = state(todo)
+    s.items.push({ id: crypto.randomUUID(), title, done: false })
+    s.selectedId = s.items.at(-1)!.id
+  },
+}))
+```
+
+Calling `s.$history.undo()` reverts both mutations together.
+
+## API
+
+```ts
+type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+```
+
+Use `ignore()` for changes that should re-render but should not enter the undo stack.
+
+```ts
+s.$history.ignore(() => {
+  s.draft = value
+})
+```
+
+`ignore()` is not the same as `silent()`. `silent()` suppresses notifications; `ignore()` only skips history recording.

--- a/apps/docs/public/llm/history.txt
+++ b/apps/docs/public/llm/history.txt
@@ -18,7 +18,7 @@ export const todo = model(
 )
 ```
 
-Use `history: true` for no limit.
+Use `history: true` for the default limit of 100 undo entries. Use `history: { limit }` to override the stack size.
 
 ## Use
 

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -29,8 +29,7 @@ export const post = model<PostState>({
 | `queryFn`         | `(arg, context) => TData \| Promise<TData>` | **Required.** Fetcher function.                                      |
 | `suspense`        | `boolean`                                   | Enable React Suspense integration. Default `false`.                  |
 | `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0`.    |
-| `cacheTime`       | `number`                                    | Alias for `gcTime`. Milliseconds before cache entry is garbage collected. |
-| `gcTime`          | `number`                                    | Milliseconds before cache entry is garbage collected.                |
+| `gcTime`          | `number`                                    | Milliseconds a cache entry survives after the model loses its last observer. Default `5 * 60_000`. |
 | `placeholderData` | `TData \| (arg, previousData) => TData`     | Data shown while fetching. Use `keepPreviousData` helper.            |
 
 ### queryFn Signature
@@ -223,7 +222,7 @@ await this.model.comments.query(postId, { staleTime: 60_000 })
 
 **Options:**
 - `force: boolean` — Bypass cache staleness check and always fetch.
-- `staleTime`, `cacheTime`, `gcTime`, `placeholderData` — Override defaults per call.
+- `staleTime`, `gcTime`, `placeholderData` — Override defaults per call.
 
 ### .refetch()
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -18,9 +18,9 @@ Add `experimentalDecorators` to your `tsconfig.json`. Without this, Next.js prod
 // tsconfig.json
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
     // ... other options
-  }
+  },
 }
 ```
 
@@ -170,6 +170,20 @@ export const post = model<PostState>({
 })
 ```
 
+History is off by default. Enable it per model when user-facing state should support undo and redo:
+
+```ts
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: { limit: 100 },
+  }
+)
+```
+
 #### Derived State & Validation
 
 `model()` accepts an optional second argument with `derive` and `rules`:
@@ -190,8 +204,8 @@ export const cart = model<CartState, CartDerived>(
     }),
     // rules: per-field validation — accessed via state.$validation
     rules: {
-      coupon: (v) => (v.length <= 20) || 'Coupon too long',
-      items: (v) => (v.length > 0) || 'Cart is empty',
+      coupon: (v) => v.length <= 20 || 'Coupon too long',
+      items: (v) => v.length > 0 || 'Cart is empty',
     },
   }
 )
@@ -199,6 +213,21 @@ export const cart = model<CartState, CartDerived>(
 
 - Derived fields are readonly and throw if assigned.
 - Validation is accessed via `state.$validation`: `{ errors: { [field]: string | null }, isValid: boolean }`.
+
+#### History
+
+No new hook is needed. Use the existing domain hook and read `$history`:
+
+```tsx
+const { history } = useTodo((s) => ({ history: s.$history }))
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+Each action method call is one history transaction. Multiple mutations inside the method are undone together. Use `s.$history.ignore(() => { ... })` for changes that should re-render but should not be recorded. This is separate from `silent()`, which suppresses notifications.
 
 ### actions/\*.ts
 
@@ -321,6 +350,8 @@ const settings = model({
 
 For full API details, see the [Persist Reference](/llm/persist.txt).
 
+For full undo/redo details, see the [History Reference](/llm/history.txt).
+
 ## Usage
 
 ```tsx
@@ -342,18 +373,18 @@ Selectors use deep equality — only re-renders when selected values change.
 
 All from `'comwit'`. Stack on class methods.
 
-| Decorator                              | Purpose                                                           |
-| -------------------------------------- | ----------------------------------------------------------------- |
-| `@OnError(fn)`                         | Error handler. Re-throw to propagate.                             |
-| `@OnSuccess(fn)`                       | Success callback.                                                 |
-| `@Debounce(ms)`                        | Debounce.                                                         |
-| `@Throttle(ms)`                        | Throttle.                                                         |
-| `@Authorized({ when, onDeny })`        | Auth guard. `when: () => boolean \| Promise<boolean>`             |
-| `@Transaction()`                       | Transactional execution (experimental, currently no-op).          |
-| `@Retry(count, options?)`              | Retry on failure with fixed or exponential backoff.               |
-| `@Queue(strategy?)`                    | Concurrency control: `'drop'`, `'queue'`, or `'replace'`.        |
-| `@Log(level?)`                         | Console logging of calls, results, and errors.                    |
-| `@Validate(validators)`               | Argument validation before execution. Throws `ValidationError`.   |
+| Decorator                       | Purpose                                                         |
+| ------------------------------- | --------------------------------------------------------------- |
+| `@OnError(fn)`                  | Error handler. Re-throw to propagate.                           |
+| `@OnSuccess(fn)`                | Success callback.                                               |
+| `@Debounce(ms)`                 | Debounce.                                                       |
+| `@Throttle(ms)`                 | Throttle.                                                       |
+| `@Authorized({ when, onDeny })` | Auth guard. `when: () => boolean \| Promise<boolean>`           |
+| `@Transaction()`                | Transactional execution (experimental, currently no-op).        |
+| `@Retry(count, options?)`       | Retry on failure with fixed or exponential backoff.             |
+| `@Queue(strategy?)`             | Concurrency control: `'drop'`, `'queue'`, or `'replace'`.       |
+| `@Log(level?)`                  | Console logging of calls, results, and errors.                  |
+| `@Validate(validators)`         | Argument validation before execution. Throws `ValidationError`. |
 
 `intercept(hooks | factory)` — create custom decorators with lifecycle hooks. Supports immediate mode (hooks object) and lazy mode (factory with `state`/`context` access).
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -52,8 +52,7 @@ export function Providers({ children }: { children: ReactNode }) {
       defaultOptions={{
         query: {
           staleTime: 30_000,
-          cacheTime: 120_000,
-          gcTime: 180_000,
+          gcTime: 5 * 60_000,
           placeholderData: keepPreviousData,
         },
       }}
@@ -328,7 +327,7 @@ export const usePost = create<PostState, PostActions>(post, {
 - Realtime methods: `.query()` · `.refetch()` · `.set()` · `.unsubscribe()`
 - Realtime-only: `connectionStatus` · `isConnected`
 - Subscribe callbacks: `update` · `set` · `refetch` · `onStatus` · `onError`
-- Options: `staleTime` · `cacheTime` · `gcTime` · `placeholderData` · `force`
+- Options: `staleTime` · `gcTime` · `placeholderData` · `force`
 - Suspense: `Query.Suspense<T>` · `Query.SuspenseInfinite<T>` · `{ suspense: true }`
 
 For full API details, see the [Query System Reference](/llm/query.txt).

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -184,6 +184,8 @@ export const todo = model(
 )
 ```
 
+`history: true` uses a default limit of 100 undo entries. Pass `history: { limit }` to override the stack size.
+
 #### Derived State & Validation
 
 `model()` accepts an optional second argument with `derive` and `rules`:

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "1.1.1",
+  "version": "2.0.0-beta.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -11,7 +11,8 @@
     "url": "https://github.com/meursyphus/comwit/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "type": "module",
   "description": "React state management for vibe coding. Less tokens. Built for Claude Code.",

--- a/packages/comwit/src/core/action.ts
+++ b/packages/comwit/src/core/action.ts
@@ -7,6 +7,7 @@ import {
 } from '../interceptors/utils'
 import { useStoreRegistry } from './provider'
 import type { BoundResourceState } from './query/types'
+import { runHistoryTransaction } from './history'
 
 export type State = <T extends object>(model: Model<T>) => BoundResourceState<T>
 
@@ -96,7 +97,7 @@ function normalizeActions<A, C extends object = Record<string, never>>(
       continue
     }
 
-    out[key] = bindValue(value as AnyFunction, instance, ctx)
+    out[key] = bindValue(value as AnyFunction, instance, ctx, key)
   }
 
   for (
@@ -110,7 +111,7 @@ function normalizeActions<A, C extends object = Record<string, never>>(
       const fn = descriptor?.value
 
       if (typeof fn !== 'function') continue
-      out[key] = bindValue(fn as AnyFunction, instance, ctx)
+      out[key] = bindValue(fn as AnyFunction, instance, ctx, key)
     }
   }
 
@@ -120,19 +121,24 @@ function normalizeActions<A, C extends object = Record<string, never>>(
 function bindValue<C extends object>(
   fn: AnyFunction,
   instance: object,
-  ctx: ActionContext<C>
+  ctx: ActionContext<C>,
+  name: string
 ): AnyFunction {
-  return resolveLazyInterceptors(fn, ctx).bind(instance)
+  const transactional = function (this: unknown, ...args: unknown[]) {
+    return runHistoryTransaction(name, () => fn.apply(this, args))
+  }
+  return resolveLazyInterceptors(fn, ctx, transactional).bind(instance)
 }
 
 function resolveLazyInterceptors<C extends object = Record<string, never>>(
   fn: AnyFunction,
-  ctx: ActionContext<C>
+  ctx: ActionContext<C>,
+  initial: AnyFunction = fn
 ): AnyFunction {
   const factories = getLazyInterceptorFactories(fn) as Array<LazyInterceptorFactory<C>>
-  if (!factories.length) return fn
+  if (!factories.length) return initial
 
-  let next = fn
+  let next = initial
   for (const factory of factories) {
     const decorator = factory({ state: ctx.state, context: ctx.context })
     if (typeof decorator !== 'function') continue

--- a/packages/comwit/src/core/action.ts
+++ b/packages/comwit/src/core/action.ts
@@ -56,7 +56,8 @@ export function useAction<A, C extends object = Record<string, never>>(
           proxy,
           bag,
           registryState,
-          defaults as Record<string, unknown> | undefined
+          defaults as Record<string, unknown> | undefined,
+          dep.key
         )
       }
 

--- a/packages/comwit/src/core/history.ts
+++ b/packages/comwit/src/core/history.ts
@@ -1,0 +1,394 @@
+import { snapshot, subscribeOps, type Path, type ProxyOp } from './proxy'
+
+export type HistoryOptions = {
+  limit?: number
+}
+
+export type HistoryConfig = boolean | HistoryOptions
+
+export type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+
+type HistoryPatch =
+  | {
+      op: 'set'
+      path: Path
+      value: unknown
+      arrayLength?: number
+    }
+  | {
+      op: 'delete'
+      path: Path
+      arrayLength?: number
+    }
+
+type HistoryEntry = {
+  label?: string
+  patches: HistoryPatch[]
+  inversePatches: HistoryPatch[]
+}
+
+type HistoryTransaction = {
+  label?: string
+  entries: Map<HistoryController, ProxyOp[]>
+}
+
+let ignoreDepth = 0
+const transactions: HistoryTransaction[] = []
+
+export function normalizeHistoryOptions(config: HistoryConfig | undefined): HistoryOptions | null {
+  if (!config) return null
+  if (config === true) return {}
+  return config
+}
+
+export function runHistoryTransaction<T>(label: string | undefined, fn: () => T): T {
+  const tx: HistoryTransaction = { label, entries: new Map() }
+  transactions.push(tx)
+
+  let result: T
+  try {
+    result = fn()
+  } catch (error) {
+    transactions.pop()
+    throw error
+  }
+
+  if (isThenable(result)) {
+    return result.then(
+      (value) => {
+        finishTransaction(tx, true)
+        return value
+      },
+      (error) => {
+        finishTransaction(tx, false)
+        throw error
+      }
+    ) as T
+  }
+
+  finishTransaction(tx, true)
+  return result
+}
+
+export function runHistoryIgnored<T>(fn: () => T): T {
+  ignoreDepth++
+  try {
+    return fn()
+  } finally {
+    ignoreDepth--
+  }
+}
+
+export function recordHistoryOp(controller: HistoryController, op: ProxyOp | undefined): void {
+  if (!op || ignoreDepth > 0 || controller.isApplying || controller.isPaused) return
+  const tx = transactions[transactions.length - 1]
+  if (!tx) return
+
+  const ops = tx.entries.get(controller)
+  if (ops) {
+    ops.push(cloneProxyOp(op))
+  } else {
+    tx.entries.set(controller, [cloneProxyOp(op)])
+  }
+}
+
+function finishTransaction(tx: HistoryTransaction, shouldCommit: boolean): void {
+  const top = transactions.pop()
+  if (top !== tx) {
+    throw new Error('[comwit] history transaction stack is corrupted')
+  }
+
+  if (!shouldCommit) return
+
+  const parent = transactions[transactions.length - 1]
+  if (parent) {
+    for (const [controller, ops] of tx.entries) {
+      const existing = parent.entries.get(controller)
+      if (existing) existing.push(...ops)
+      else parent.entries.set(controller, ops)
+    }
+    return
+  }
+
+  for (const [controller, ops] of tx.entries) {
+    controller.commit(ops, tx.label)
+  }
+}
+
+function isThenable<T>(value: unknown): value is PromiseLike<T> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as PromiseLike<T>).then === 'function'
+  )
+}
+
+export class HistoryController {
+  readonly apiMethods: Omit<HistoryApi, 'canUndo' | 'canRedo' | 'isPaused'>
+
+  private past: HistoryEntry[] = []
+  private future: HistoryEntry[] = []
+  private listeners = new Set<() => void>()
+  private cleanup: (() => void) | null = null
+  private paused = false
+  private applying = false
+  private readonly limit: number | null
+
+  constructor(
+    private readonly proxy: object,
+    options: HistoryOptions = {}
+  ) {
+    this.limit = typeof options.limit === 'number' && options.limit >= 0 ? options.limit : null
+    this.apiMethods = {
+      undo: (steps) => this.undo(steps),
+      redo: (steps) => this.redo(steps),
+      clear: () => this.clear(),
+      pause: () => this.pause(),
+      resume: () => this.resume(),
+      ignore: (fn) => runHistoryIgnored(fn),
+      transaction: ((labelOrFn: string | (() => unknown), maybeFn?: () => unknown) => {
+        const label = typeof labelOrFn === 'string' ? labelOrFn : undefined
+        const fn = typeof labelOrFn === 'string' ? maybeFn! : labelOrFn
+        return runHistoryTransaction(label, fn)
+      }) as HistoryApi['transaction'],
+    }
+
+    this.cleanup = subscribeOps(proxy, (op) => recordHistoryOp(this, op))
+  }
+
+  get isApplying(): boolean {
+    return this.applying
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  get canUndo(): boolean {
+    return this.past.length > 0
+  }
+
+  get canRedo(): boolean {
+    return this.future.length > 0
+  }
+
+  getApi(): HistoryApi {
+    return {
+      canUndo: this.canUndo,
+      canRedo: this.canRedo,
+      isPaused: this.isPaused,
+      ...this.apiMethods,
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  destroy(): void {
+    this.cleanup?.()
+    this.cleanup = null
+    this.listeners.clear()
+  }
+
+  commit(ops: ProxyOp[], label?: string): void {
+    const entry = createHistoryEntry(ops, label)
+    if (!entry) return
+
+    this.past.push(entry)
+    if (this.limit !== null && this.past.length > this.limit) {
+      this.past.splice(0, this.past.length - this.limit)
+    }
+    this.future = []
+    this.notify()
+  }
+
+  undo(steps = 1): void {
+    const count = normalizeStepCount(steps)
+    for (let i = 0; i < count; i++) {
+      const entry = this.past.pop()
+      if (!entry) break
+      this.apply(entry.inversePatches)
+      this.future.push(entry)
+    }
+    this.notify()
+  }
+
+  redo(steps = 1): void {
+    const count = normalizeStepCount(steps)
+    for (let i = 0; i < count; i++) {
+      const entry = this.future.pop()
+      if (!entry) break
+      this.apply(entry.patches)
+      this.past.push(entry)
+    }
+    this.notify()
+  }
+
+  clear(): void {
+    if (!this.past.length && !this.future.length) return
+    this.past = []
+    this.future = []
+    this.notify()
+  }
+
+  pause(): void {
+    if (this.paused) return
+    this.paused = true
+    this.notify()
+  }
+
+  resume(): void {
+    if (!this.paused) return
+    this.paused = false
+    this.notify()
+  }
+
+  private apply(patches: HistoryPatch[]): void {
+    this.applying = true
+    try {
+      for (const patch of patches) {
+        applyPatch(this.proxy, patch)
+      }
+    } finally {
+      this.applying = false
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener())
+  }
+}
+
+export function createHistoryController(proxy: object, options: HistoryOptions): HistoryController {
+  return new HistoryController(proxy, options)
+}
+
+function createHistoryEntry(ops: ProxyOp[], label?: string): HistoryEntry | null {
+  const patches: HistoryPatch[] = []
+  const inversePatches: HistoryPatch[] = []
+
+  for (const op of ops) {
+    const patch = toPatch(op)
+    if (!patch) continue
+    patches.push(patch.patch)
+    inversePatches.unshift(patch.inversePatch)
+  }
+
+  if (!patches.length) return null
+  return { label, patches, inversePatches }
+}
+
+function toPatch(op: ProxyOp): { patch: HistoryPatch; inversePatch: HistoryPatch } | null {
+  if (op[0] === 'set') {
+    const [, path, value, prevValue, hadPrevValue, meta] = op
+    const patch: HistoryPatch = {
+      op: 'set',
+      path: [...path],
+      value: cloneHistoryValue(value),
+      arrayLength: meta?.nextLength,
+    }
+    const inversePatch: HistoryPatch = hadPrevValue
+      ? {
+          op: 'set',
+          path: [...path],
+          value: cloneHistoryValue(prevValue),
+          arrayLength: meta?.prevLength,
+        }
+      : {
+          op: 'delete',
+          path: [...path],
+          arrayLength: meta?.prevLength,
+        }
+    return { patch, inversePatch }
+  }
+
+  const [, path, prevValue, hadPrevValue] = op
+  if (!hadPrevValue) return null
+  return {
+    patch: { op: 'delete', path: [...path] },
+    inversePatch: { op: 'set', path: [...path], value: cloneHistoryValue(prevValue) },
+  }
+}
+
+function applyPatch(root: object, patch: HistoryPatch): void {
+  const parent = getPatchParent(root, patch.path)
+  if (!parent) return
+
+  const key = patch.path[patch.path.length - 1]
+  if (patch.op === 'set') {
+    Reflect.set(parent, key, cloneHistoryValue(patch.value))
+  } else {
+    Reflect.deleteProperty(parent, key)
+  }
+
+  if (typeof patch.arrayLength === 'number' && Array.isArray(parent)) {
+    parent.length = patch.arrayLength
+  }
+}
+
+function getPatchParent(root: object, path: Path): any {
+  if (!path.length) return null
+
+  let current: any = root
+  for (let i = 0; i < path.length - 1; i++) {
+    current = current?.[path[i]]
+    if (current === null || current === undefined) return null
+  }
+  return current
+}
+
+function cloneProxyOp(op: ProxyOp): ProxyOp {
+  if (op[0] === 'set') {
+    const [, path, value, prevValue, hadPrevValue, meta] = op
+    return [
+      'set',
+      [...path],
+      cloneHistoryValue(value),
+      cloneHistoryValue(prevValue),
+      hadPrevValue,
+      meta ? { ...meta } : undefined,
+    ]
+  }
+
+  const [, path, prevValue, hadPrevValue, meta] = op
+  return [
+    'delete',
+    [...path],
+    cloneHistoryValue(prevValue),
+    hadPrevValue,
+    meta ? { ...meta } : undefined,
+  ]
+}
+
+function cloneHistoryValue(value: unknown): unknown {
+  if (value && typeof value === 'object') {
+    try {
+      return structuredClone(snapshot(value as object))
+    } catch {}
+    try {
+      return structuredClone(value)
+    } catch {
+      return value
+    }
+  }
+  return value
+}
+
+function normalizeStepCount(steps: number): number {
+  if (!Number.isFinite(steps)) return 1
+  return Math.max(0, Math.floor(steps))
+}

--- a/packages/comwit/src/core/history.ts
+++ b/packages/comwit/src/core/history.ts
@@ -6,6 +6,8 @@ export type HistoryOptions = {
 
 export type HistoryConfig = boolean | HistoryOptions
 
+export const DEFAULT_HISTORY_LIMIT = 100
+
 export type HistoryApi = {
   canUndo: boolean
   canRedo: boolean
@@ -49,8 +51,8 @@ const transactions: HistoryTransaction[] = []
 
 export function normalizeHistoryOptions(config: HistoryConfig | undefined): HistoryOptions | null {
   if (!config) return null
-  if (config === true) return {}
-  return config
+  if (config === true) return { limit: DEFAULT_HISTORY_LIMIT }
+  return { limit: config.limit ?? DEFAULT_HISTORY_LIMIT }
 }
 
 export function runHistoryTransaction<T>(label: string | undefined, fn: () => T): T {
@@ -144,13 +146,16 @@ export class HistoryController {
   private cleanup: (() => void) | null = null
   private paused = false
   private applying = false
-  private readonly limit: number | null
+  private readonly limit: number
 
   constructor(
     private readonly proxy: object,
     options: HistoryOptions = {}
   ) {
-    this.limit = typeof options.limit === 'number' && options.limit >= 0 ? options.limit : null
+    this.limit =
+      typeof options.limit === 'number' && options.limit >= 0
+        ? options.limit
+        : DEFAULT_HISTORY_LIMIT
     this.apiMethods = {
       undo: (steps) => this.undo(steps),
       redo: (steps) => this.redo(steps),
@@ -209,7 +214,7 @@ export class HistoryController {
     if (!entry) return
 
     this.past.push(entry)
-    if (this.limit !== null && this.past.length > this.limit) {
+    if (this.past.length > this.limit) {
       this.past.splice(0, this.past.length - this.limit)
     }
     this.future = []

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -21,6 +21,7 @@ export type { FieldPlugin, PluginBag } from './plugin'
 import { persistPlugin } from './persist'
 import { persist, type PersistAdapter, type PersistOptions, type PersistDefaults } from './persist'
 import { initDevTools } from './devtools'
+import type { HistoryApi, HistoryOptions, HistoryConfig } from './history'
 
 import { computedPlugin } from './computed'
 import { computed } from './computed'
@@ -82,4 +83,7 @@ export type {
   PersistOptions,
   PersistDefaults,
   Snapshotable,
+  HistoryApi,
+  HistoryOptions,
+  HistoryConfig,
 }

--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -5,17 +5,27 @@ import { useStoreRegistry } from './provider'
 import { isEqual } from '../utils'
 import { isSilent } from './silent'
 import { COMPUTED_PLUGIN_NAME, createComputedProxy, getComputedSnapshot } from './computed'
+import {
+  createHistoryController,
+  normalizeHistoryOptions,
+  type HistoryApi,
+  type HistoryConfig,
+  type HistoryController,
+  type HistoryOptions,
+} from './history'
 
 export type StoreEntry<T extends object = any> = {
   proxy: T
   getSnapshot(): T
   subscribe(listener: () => void): () => void
+  history?: HistoryController
 }
 
 export type ModelOptions<T extends object, D extends object = {}> = {
   derive?: (state: T) => { [K in keyof D]: () => D[K] }
   rules?: { [K in keyof T]?: (value: T[K]) => true | string }
   onObserve?: (state: T) => void | (() => void)
+  history?: HistoryConfig
 }
 
 export type ValidationState<T> = {
@@ -24,6 +34,10 @@ export type ValidationState<T> = {
 }
 
 export function model<T extends object>(initial: T): Model<T>
+export function model<T extends object, D extends object>(
+  initial: T,
+  options: ModelOptions<T, D> & { history: true | HistoryOptions }
+): Model<T & Readonly<D> & { $validation: ValidationState<T>; $history: HistoryApi }>
 export function model<T extends object, D extends object>(
   initial: T,
   options: ModelOptions<T, D>
@@ -48,6 +62,8 @@ export function model<T extends object, D extends object = {}>(
     onObserve: options?.onObserve as Model<T & Readonly<D>>['onObserve'],
     instance(): StoreEntry<T & Readonly<D>> {
       const p = createProxy(cloneState())
+      const historyOptions = normalizeHistoryOptions(options?.history)
+      const history = historyOptions ? createHistoryController(p, historyOptions) : null
 
       const deriveFactory = options?.derive
       const rules = options?.rules
@@ -61,7 +77,8 @@ export function model<T extends object, D extends object = {}>(
 
       const computedBag = pluginBags.get(COMPUTED_PLUGIN_NAME)
       const hasComputed = computedBag != null && computedBag.size > 0
-      const hasExtensions = derivedGetters != null || rules != null || hasComputed
+      const hasHistory = history != null
+      const hasExtensions = derivedGetters != null || rules != null || hasComputed || hasHistory
 
       let computedProxyRef: object | null = null
       let publicProxy: unknown = p
@@ -73,6 +90,9 @@ export function model<T extends object, D extends object = {}>(
         const base = publicProxy as object
         publicProxy = new Proxy(base, {
           get(target, prop, receiver) {
+            if (prop === '$history' && history) {
+              return history.getApi()
+            }
             if (typeof prop === 'string' && derivedKeys?.has(prop)) {
               return derivedGetters![prop]()
             }
@@ -88,6 +108,25 @@ export function model<T extends object, D extends object = {}>(
             if (prop === '$validation') {
               throw new Error('Cannot set $validation')
             }
+            if (prop === '$history') {
+              throw new Error('Cannot set $history')
+            }
+            return Reflect.set(target, prop, value, receiver)
+          },
+        })
+      } else if (history) {
+        const base = publicProxy as object
+        publicProxy = new Proxy(base, {
+          get(target, prop, receiver) {
+            if (prop === '$history') {
+              return history.getApi()
+            }
+            return Reflect.get(target, prop, receiver)
+          },
+          set(target, prop, value, receiver) {
+            if (prop === '$history') {
+              throw new Error('Cannot set $history')
+            }
             return Reflect.set(target, prop, value, receiver)
           },
         })
@@ -95,6 +134,7 @@ export function model<T extends object, D extends object = {}>(
 
       return {
         proxy: publicProxy as T & Readonly<D>,
+        history: history ?? undefined,
         getSnapshot() {
           if (!hasExtensions) return snapshot(p) as T & Readonly<D>
 
@@ -115,12 +155,21 @@ export function model<T extends object, D extends object = {}>(
             result.$validation = computeValidation(p as Record<string, unknown>, rules)
           }
 
+          if (history) {
+            result.$history = history.getApi()
+          }
+
           return Object.freeze(result) as T & Readonly<D>
         },
         subscribe(listener) {
-          return subscribe(p, () => {
+          const unsubProxy = subscribe(p, () => {
             if (!isSilent()) listener()
           })
+          const unsubHistory = history?.subscribe(listener)
+          return () => {
+            unsubProxy()
+            unsubHistory?.()
+          }
         },
       }
     },

--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -228,21 +228,27 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
   const subscribe = useCallback(
     (listener: () => void) => {
       lifecycle.subscriberCount++
-      if (lifecycle.subscriberCount === 1 && m.onObserve) {
-        const result = m.onObserve(store.proxy)
-        lifecycle.cleanup = typeof result === 'function' ? result : null
+      if (lifecycle.subscriberCount === 1) {
+        notifySubscriberChange(m, registry, true)
+        if (m.onObserve) {
+          const result = m.onObserve(store.proxy)
+          lifecycle.cleanup = typeof result === 'function' ? result : null
+        }
       }
       const unsubProxy = store.subscribe(listener)
       return () => {
         unsubProxy()
         lifecycle.subscriberCount--
-        if (lifecycle.subscriberCount === 0 && lifecycle.cleanup) {
-          lifecycle.cleanup()
-          lifecycle.cleanup = null
+        if (lifecycle.subscriberCount === 0) {
+          if (lifecycle.cleanup) {
+            lifecycle.cleanup()
+            lifecycle.cleanup = null
+          }
+          notifySubscriberChange(m, registry, false)
         }
       }
     },
-    [store, lifecycle, m]
+    [store, lifecycle, m, registry]
   )
 
   const getSnapshot = useCallback(() => {
@@ -270,6 +276,21 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
   }
 
   return result
+}
+
+function notifySubscriberChange(
+  m: Model<any>,
+  registry: ReturnType<typeof useStoreRegistry>,
+  hasObservers: boolean
+): void {
+  const plugins = getPlugins()
+  for (const plugin of plugins) {
+    if (!plugin.onSubscriberChange) continue
+    const bag = m.pluginBags.get(plugin.name)
+    if (!bag || bag.size === 0) continue
+    const registryState = registry.pluginStates.get(plugin.name)
+    plugin.onSubscriberChange(m.key, bag, registryState, hasObservers)
+  }
 }
 
 function normalize(value: unknown, path: string, pluginBags: Map<string, PluginBag>): unknown {

--- a/packages/comwit/src/core/plugin.ts
+++ b/packages/comwit/src/core/plugin.ts
@@ -29,12 +29,15 @@ export type FieldPlugin = {
   /**
    * Called when action's state() binds a model proxy.
    * Wraps the proxy with plugin-specific accessors (e.g. .query(), .refetch()).
+   * `modelKey` identifies the owning model; plugins that track per-model
+   * runtime state should index by it.
    */
   bindState(
     proxy: object,
     bag: PluginBag,
     registryState: unknown,
-    defaults?: Record<string, unknown>
+    defaults?: Record<string, unknown>,
+    modelKey?: symbol
   ): object
 
   /**
@@ -42,6 +45,19 @@ export type FieldPlugin = {
    * Used by query plugin to throw promises for Suspense or errors for ErrorBoundary.
    */
   onRender?(bag: PluginBag, registryState: unknown): void
+
+  /**
+   * Called when a model's observer count transitions to/from 0.
+   * Fires with `hasObservers=true` when count goes 0→1, and
+   * `hasObservers=false` when count goes 1→0. Used by the query plugin
+   * to schedule/cancel cache eviction (TanStack-style gcTime).
+   */
+  onSubscriberChange?(
+    modelKey: symbol,
+    bag: PluginBag,
+    registryState: unknown,
+    hasObservers: boolean
+  ): void
 }
 
 const plugins: FieldPlugin[] = []

--- a/packages/comwit/src/core/proxy.ts
+++ b/packages/comwit/src/core/proxy.ts
@@ -11,11 +11,22 @@ const $ref = Symbol('ref') // marks objects excluded from proxying
 const $snap = Symbol('snap') // snapshot cache on target
 const $proxy = Symbol('proxy') // cached proxy on base object
 
-type Path = (string | symbol)[]
-type Op =
-  | [op: 'set', path: Path, value: unknown, prevValue: unknown]
-  | [op: 'delete', path: Path, prevValue: unknown]
-type Listener = (op: Op | undefined, nextVersion: number) => void
+export type Path = (string | symbol)[]
+export type ProxyOpMeta = {
+  prevLength?: number
+  nextLength?: number
+}
+export type ProxyOp =
+  | [
+      op: 'set',
+      path: Path,
+      value: unknown,
+      prevValue: unknown,
+      hadPrevValue: boolean,
+      meta?: ProxyOpMeta,
+    ]
+  | [op: 'delete', path: Path, prevValue: unknown, hadPrevValue: boolean, meta?: ProxyOpMeta]
+type Listener = (op: ProxyOp | undefined, nextVersion: number) => void
 type RemoveListener = () => void
 type AddListener = (listener: Listener) => RemoveListener
 type ProxyState = readonly [
@@ -96,7 +107,7 @@ function createHandler<T extends object>(
   isInitializing: () => boolean,
   addPropListener: (prop: string | symbol, propValue: unknown) => void,
   removePropListener: (prop: string | symbol) => void,
-  notifyUpdate: (op: Op | undefined) => void
+  notifyUpdate: (op: ProxyOp | undefined) => void
 ): ProxyHandler<T> {
   return {
     get(target: T, prop: string | symbol, receiver: object) {
@@ -110,17 +121,19 @@ function createHandler<T extends object>(
       return Reflect.get(target, prop, receiver)
     },
     deleteProperty(target: T, prop: string | symbol) {
+      const hadPrevValue = Reflect.has(target, prop)
       const prevValue = Reflect.get(target, prop)
       removePropListener(prop)
       const deleted = Reflect.deleteProperty(target, prop)
       if (deleted) {
-        notifyUpdate(['delete', [prop], prevValue])
+        notifyUpdate(['delete', [prop], prevValue, hadPrevValue])
       }
       return deleted
     },
     set(target: T, prop: string | symbol, value: any, receiver: object) {
       const hasPrevValue = !isInitializing() && Reflect.has(target, prop)
       const prevValue = Reflect.get(target, prop, receiver)
+      const prevLength = Array.isArray(target) ? target.length : undefined
       const cachedProxy = isObject(value) && getCachedProxy(value)
       if (
         hasPrevValue &&
@@ -132,7 +145,12 @@ function createHandler<T extends object>(
       const nextValue = !getProxyState(value) && canProxy(value) ? proxyInner(value) : value
       addPropListener(prop, nextValue)
       Reflect.set(target, prop, nextValue, receiver)
-      notifyUpdate(['set', [prop], value, prevValue])
+      const nextLength = Array.isArray(target) ? target.length : undefined
+      const meta =
+        prevLength !== undefined && nextLength !== undefined && prevLength !== nextLength
+          ? { prevLength, nextLength }
+          : undefined
+      notifyUpdate(['set', [prop], value, prevValue, hasPrevValue, meta])
       return true
     },
   }
@@ -156,7 +174,7 @@ function proxyInner<T extends object>(baseObject: T): T {
   }
   let version = globalVersion
   const listeners = new Set<Listener>()
-  const notifyUpdate = (op: Op | undefined, nextVersion = ++globalVersion) => {
+  const notifyUpdate = (op: ProxyOp | undefined, nextVersion = ++globalVersion) => {
     if (version !== nextVersion) {
       checkVersion = version = nextVersion
       listeners.forEach((listener) => listener(op, nextVersion))
@@ -178,7 +196,7 @@ function proxyInner<T extends object>(baseObject: T): T {
   const createPropListener =
     (prop: string | symbol): Listener =>
     (op, nextVersion) => {
-      let newOp: Op | undefined
+      let newOp: ProxyOp | undefined
       if (op) {
         newOp = [...op]
         newOp[1] = [prop, ...(newOp[1] as Path)]
@@ -300,6 +318,29 @@ export function subscribe<T extends object>(state: T, callback: () => void): () 
   const listener: Listener = () => {
     if (isListenerActive) {
       callback()
+    }
+  }
+  const removeListener = addListener(listener)
+  isListenerActive = true
+  return () => {
+    isListenerActive = false
+    removeListener()
+  }
+}
+
+export function subscribeOps<T extends object>(
+  state: T,
+  callback: (op: ProxyOp | undefined, nextVersion: number) => void
+): () => void {
+  const proxyState = getProxyState(state)
+  if (!proxyState) {
+    throw new Error('Please use proxy object')
+  }
+  const addListener = proxyState[2]
+  let isListenerActive = false
+  const listener: Listener = (op, nextVersion) => {
+    if (isListenerActive) {
+      callback(op, nextVersion)
     }
   }
   const removeListener = addListener(listener)

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -1,4 +1,5 @@
 import { snapshot } from '../proxy'
+import { DEFAULT_GC_TIME } from './registry'
 import {
   RESOURCE_QUERY_OPTION_KEYS,
   type AnyResourceDescriptor,
@@ -42,10 +43,9 @@ function normalizeError(error: unknown) {
   return 'Unknown error'
 }
 
-function resolveGcTime(options: QueryDefaultOptions): number | undefined {
-  if (typeof options.cacheTime === 'number') return options.cacheTime
+function resolveGcTime(options: QueryDefaultOptions): number {
   if (typeof options.gcTime === 'number') return options.gcTime
-  return undefined
+  return DEFAULT_GC_TIME
 }
 
 export function mergeResult(state: ResourceDataLike, result: unknown, appendData = false) {
@@ -162,14 +162,15 @@ function cloneRuntime(path: string): ResourceRuntimeState {
     activeKey: undefined,
     fetchId: 0,
     cacheEntries: new Map(),
+    gcTime: DEFAULT_GC_TIME,
+    gcTimers: new Map(),
   }
 }
 
 function createCacheEntry(
   state: ResourceDataLike,
   key: QueryCacheKey,
-  arg: unknown,
-  gcTime?: number
+  arg: unknown
 ): QueryCacheEntry {
   return {
     key,
@@ -177,7 +178,6 @@ function createCacheEntry(
     hasQueried: false,
     lastFetchedAt: 0,
     cursorHistory: [],
-    gcTime,
     state: snapshot(state) as ResourceDataLike,
   }
 }
@@ -192,17 +192,44 @@ function updateCachedState(entry: QueryCacheEntry, source: ResourceDataLike) {
   entry.state = snapshot(source) as ResourceDataLike
 }
 
-function cleanupExpiredCacheEntries(runtime: ResourceRuntimeState, now: number) {
-  for (const [key, entry] of runtime.cacheEntries) {
-    if (typeof entry.gcTime !== 'number') continue
-    if (entry.lastFetchedAt === 0) continue
-    if (now - entry.lastFetchedAt < entry.gcTime) continue
-
-    runtime.cacheEntries.delete(key)
-    if (runtime.activeKey === key) {
-      runtime.activeKey = undefined
-      runtime.lastArg = undefined
+/**
+ * Schedules eviction for every cache entry on every runtime owned by the
+ * given model key. Called by the query plugin when the model's observer
+ * count transitions to 0. Subsequent calls are idempotent — existing
+ * timers are left in place.
+ */
+export function scheduleModelGc(registry: QueryBindingRegistry, modelKey: symbol) {
+  const runtimes = registry.runtimesByModel.get(modelKey)
+  if (!runtimes) return
+  for (const runtime of runtimes) {
+    for (const [key] of runtime.cacheEntries) {
+      if (runtime.gcTimers.has(key)) continue
+      const timer = setTimeout(() => {
+        runtime.gcTimers.delete(key)
+        runtime.cacheEntries.delete(key)
+        if (runtime.activeKey === key) {
+          runtime.activeKey = undefined
+          runtime.lastArg = undefined
+        }
+      }, runtime.gcTime)
+      runtime.gcTimers.set(key, timer)
     }
+  }
+}
+
+/**
+ * Cancels all pending GC timers across every runtime owned by the model.
+ * Called by the query plugin when the model gains its first observer
+ * (subscriber count transitions from 0 to 1).
+ */
+export function cancelModelGc(registry: QueryBindingRegistry, modelKey: symbol) {
+  const runtimes = registry.runtimesByModel.get(modelKey)
+  if (!runtimes) return
+  for (const runtime of runtimes) {
+    for (const timer of runtime.gcTimers.values()) {
+      clearTimeout(timer)
+    }
+    runtime.gcTimers.clear()
   }
 }
 
@@ -254,7 +281,8 @@ export function createResourceAccessor(
   path: string,
   defaults: QueryDefaultOptions | undefined,
   registry: QueryBindingRegistry,
-  modelState?: object
+  modelState?: object,
+  modelKey?: symbol
 ): ResourceDataLike {
   if (registry.boundResourceValue.has(state)) {
     return registry.boundResourceValue.get(state) as ResourceDataLike
@@ -262,7 +290,20 @@ export function createResourceAccessor(
 
   const runtime = registry.boundResourceRuntime.get(state) ?? cloneRuntime(path)
   runtime.path = path
+  runtime.gcTime = resolveGcTime({
+    ...(defaults ?? {}),
+    ...(descriptor.options as QueryDefaultOptions),
+  })
   registry.boundResourceRuntime.set(state, runtime)
+
+  if (modelKey !== undefined) {
+    let set = registry.runtimesByModel.get(modelKey)
+    if (!set) {
+      set = new Set()
+      registry.runtimesByModel.set(modelKey, set)
+    }
+    set.add(runtime)
+  }
 
   const getActiveEntry = () => {
     if (!runtime.activeKey) return
@@ -350,9 +391,8 @@ export function createResourceAccessor(
 
     const staleTime =
       typeof effectiveOptions.staleTime === 'number' ? effectiveOptions.staleTime : 0
-    const gcTime = resolveGcTime(effectiveOptions)
+    runtime.gcTime = resolveGcTime(effectiveOptions)
     const now = Date.now()
-    cleanupExpiredCacheEntries(runtime, now)
 
     const queryArg = isRefetch ? activeEntryBefore?.arg : hasArg ? arg : runtime.lastArg
     const queryKey = serializeQueryArg(queryArg)
@@ -361,11 +401,16 @@ export function createResourceAccessor(
 
     let entry = runtime.cacheEntries.get(queryKey)
     if (!entry) {
-      entry = createCacheEntry(state, queryKey, queryArg, gcTime)
+      entry = createCacheEntry(state, queryKey, queryArg)
       runtime.cacheEntries.set(queryKey, entry)
+    } else {
+      const pending = runtime.gcTimers.get(queryKey)
+      if (pending !== undefined) {
+        clearTimeout(pending)
+        runtime.gcTimers.delete(queryKey)
+      }
     }
 
-    entry.gcTime = gcTime
     entry.arg = queryArg
 
     const shouldFetch =

--- a/packages/comwit/src/core/query/bind.ts
+++ b/packages/comwit/src/core/query/bind.ts
@@ -31,7 +31,8 @@ function bindPath(
   path = '',
   defaults: QueryDefaultOptions | undefined,
   registry: QueryBindingRegistry,
-  modelState?: object
+  modelState?: object,
+  modelKey?: symbol
 ): any {
   if (!descriptors.size) return state
 
@@ -57,12 +58,13 @@ function bindPath(
           nextPath,
           defaults,
           registry,
-          modelState
+          modelState,
+          modelKey
         )
       }
 
       if (isRecord(next) && hasNestedPath(descriptors, nextPath)) {
-        return bindPath(next, descriptors, nextPath, defaults, registry, modelState)
+        return bindPath(next, descriptors, nextPath, defaults, registry, modelState, modelKey)
       }
 
       return next
@@ -80,8 +82,17 @@ export function bindResourceState<T extends object>(
   modelState: T,
   resourceDescriptors: ResourceDescriptorMap,
   defaults?: QueryDefaultOptions,
-  registry: QueryBindingRegistry = createQueryBindingRegistry()
+  registry: QueryBindingRegistry = createQueryBindingRegistry(),
+  modelKey?: symbol
 ): T {
   if (!resourceDescriptors.size) return modelState
-  return bindPath(modelState, resourceDescriptors, '', defaults, registry, modelState) as T
+  return bindPath(
+    modelState,
+    resourceDescriptors,
+    '',
+    defaults,
+    registry,
+    modelState,
+    modelKey
+  ) as T
 }

--- a/packages/comwit/src/core/query/plugin.ts
+++ b/packages/comwit/src/core/query/plugin.ts
@@ -1,6 +1,7 @@
 import { registerPlugin, type FieldPlugin, type PluginBag } from '../plugin'
 import { isResourceDescriptor } from './descriptor'
 import { bindResourceState } from './bind'
+import { cancelModelGc, scheduleModelGc } from './accessor'
 import { checkSuspense } from './suspense'
 import { createQueryBindingRegistry } from './registry'
 import type {
@@ -30,7 +31,8 @@ export const queryPlugin: FieldPlugin = {
     proxy: object,
     bag: PluginBag,
     registryState: unknown,
-    defaults?: Record<string, unknown>
+    defaults?: Record<string, unknown>,
+    modelKey?: symbol
   ): object {
     if (bag.size === 0) return proxy
     const descriptors = bag as ResourceDescriptorMap
@@ -38,7 +40,8 @@ export const queryPlugin: FieldPlugin = {
       proxy as any,
       descriptors,
       defaults as QueryDefaultOptions | undefined,
-      registryState as QueryBindingRegistry
+      registryState as QueryBindingRegistry,
+      modelKey
     )
   },
 
@@ -46,6 +49,20 @@ export const queryPlugin: FieldPlugin = {
     if (bag.size === 0) return
     const descriptors = bag as ResourceDescriptorMap
     checkSuspense(descriptors, registryState as QueryBindingRegistry)
+  },
+
+  onSubscriberChange(
+    modelKey: symbol,
+    _bag: PluginBag,
+    registryState: unknown,
+    hasObservers: boolean
+  ): void {
+    const registry = registryState as QueryBindingRegistry
+    if (hasObservers) {
+      cancelModelGc(registry, modelKey)
+    } else {
+      scheduleModelGc(registry, modelKey)
+    }
   },
 }
 

--- a/packages/comwit/src/core/query/registry.ts
+++ b/packages/comwit/src/core/query/registry.ts
@@ -1,10 +1,17 @@
 import type { QueryBindingRegistry } from './types'
 
+/**
+ * Default time (ms) a cache entry survives after the owning model loses
+ * its last observer. Mirrors TanStack Query v5's `gcTime` default.
+ */
+export const DEFAULT_GC_TIME = 5 * 60 * 1000
+
 export function createQueryBindingRegistry(): QueryBindingRegistry {
   return {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
     boundResourceRuntime: new WeakMap(),
     suspense: new Map(),
+    runtimesByModel: new Map(),
   }
 }

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -21,13 +21,11 @@ export const RESOURCE_QUERY_OPTION_KEYS = new Set([
   'force',
   'placeholderData',
   'staleTime',
-  'cacheTime',
   'gcTime',
 ])
 
 export type QueryDefaultOptions = {
   staleTime?: number
-  cacheTime?: number
   gcTime?: number
   placeholderData?: PlaceholderData<unknown, unknown>
 }
@@ -297,7 +295,6 @@ export type QueryCacheEntry = {
   lastFetchedAt: number
   lastResult?: unknown
   cursorHistory: Array<string | null>
-  gcTime?: number
   state: ResourceDataLike
 }
 
@@ -311,6 +308,12 @@ export type QueryBindingRegistry = {
   boundPathProxy: WeakMap<object, Map<string, object>>
   boundResourceRuntime: WeakMap<object, ResourceRuntimeState>
   suspense: Map<string, SuspenseState>
+  /**
+   * Tracks every runtime created in this registry, indexed by the owning
+   * model's key. Used by the GC scheduler to enumerate which cache entries
+   * belong to a model when its observer count transitions to 0.
+   */
+  runtimesByModel: Map<symbol, Set<ResourceRuntimeState>>
 }
 
 export type ResourceRuntimeState = {
@@ -322,4 +325,16 @@ export type ResourceRuntimeState = {
   subscriptionCleanup?: () => void
   refetchIntervalId?: ReturnType<typeof setInterval>
   streamAbortController?: AbortController
+  /**
+   * Configured gcTime for this runtime, resolved at bind time from
+   * descriptor options + provider defaults. Used when scheduling eviction
+   * after the owning model loses its last observer.
+   */
+  gcTime: number
+  /**
+   * Pending eviction timers keyed by cache entry key. Populated when the
+   * owning model's observer count drops to 0 and cleared when it rises
+   * back to >=1.
+   */
+  gcTimers: Map<QueryCacheKey, ReturnType<typeof setTimeout>>
 }

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -223,9 +223,11 @@ export type BoundResourceState<T> =
               ? BoundSingleResourceState<TData, unknown>
               : T extends (infer U)[]
                 ? BoundResourceState<U>[]
-                : T extends object
-                  ? { [K in keyof T]: BoundResourceState<T[K]> }
-                  : T
+                : T extends (...args: any[]) => any
+                  ? T
+                  : T extends object
+                    ? { [K in keyof T]: BoundResourceState<T[K]> }
+                    : T
 
 export type DependentQueryOptions<TData> = {
   enabled?: (state: any) => boolean

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -25,5 +25,8 @@ export type {
   PersistOptions,
   PersistDefaults,
   Snapshotable,
+  HistoryApi,
+  HistoryOptions,
+  HistoryConfig,
 } from './core'
 export * from './interceptors'

--- a/packages/comwit/tests/history.test.tsx
+++ b/packages/comwit/tests/history.test.tsx
@@ -143,6 +143,82 @@ describe('history', () => {
     expect(result.current.state.$history.canRedo).toBe(false)
   })
 
+  test('uses a default limit of 100 undo entries', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      increment() {
+        state(counter).count += 1
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ increment: () => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      for (let i = 0; i < 101; i++) {
+        result.current.actions.increment()
+      }
+    })
+
+    expect(result.current.state.count).toBe(101)
+
+    await act(async () => {
+      result.current.state.$history.undo(100)
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.$history.canUndo).toBe(false)
+  })
+
+  test('buckets one action transaction by each changed model', async () => {
+    const profile = model({ name: 'Ada' }, { history: true })
+    const settings = model({ theme: 'light' }, { history: true })
+    const actions = action(({ state }) => ({
+      updateBoth() {
+        state(profile).name = 'Grace'
+        state(settings).theme = 'dark'
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        profile: useModel(profile),
+        settings: useModel(settings),
+        actions: useAction<{ updateBoth: () => void }>([actions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.updateBoth()
+    })
+
+    expect(result.current.profile.name).toBe('Grace')
+    expect(result.current.settings.theme).toBe('dark')
+    expect(result.current.profile.$history.canUndo).toBe(true)
+    expect(result.current.settings.$history.canUndo).toBe(true)
+
+    await act(async () => {
+      result.current.profile.$history.undo()
+    })
+
+    expect(result.current.profile.name).toBe('Ada')
+    expect(result.current.settings.theme).toBe('dark')
+
+    await act(async () => {
+      result.current.settings.$history.undo()
+    })
+
+    expect(result.current.settings.theme).toBe('light')
+  })
+
   test('supports ignore without suppressing rendering', async () => {
     const counter = model({ count: 0 }, { history: true })
     const counterActions = action(({ state }) => ({

--- a/packages/comwit/tests/history.test.tsx
+++ b/packages/comwit/tests/history.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from 'vitest'
+import React from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { action, ComwitProvider, create, model, useAction, useModel } from '../src'
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ComwitProvider>{children}</ComwitProvider>
+  }
+}
+
+describe('history', () => {
+  test('is disabled by default', () => {
+    const counter = model({ count: 0 })
+    const store = counter.instance()
+
+    expect('$history' in store.getSnapshot()).toBe(false)
+  })
+
+  test('exposes $history when enabled', () => {
+    const counter = model({ count: 0 }, { history: true })
+    const store = counter.instance()
+    const snap = store.getSnapshot()
+
+    expect(snap.$history.canUndo).toBe(false)
+    expect(snap.$history.canRedo).toBe(false)
+    expect(typeof snap.$history.undo).toBe('function')
+    expect(typeof snap.$history.redo).toBe('function')
+  })
+
+  test('records one action method as one undo step', async () => {
+    const counter = model({ count: 0, label: 'idle' }, { history: true })
+    const counterActions = action(({ state }) => ({
+      update() {
+        const s = state(counter)
+        s.count += 1
+        s.label = 'updated'
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ update: () => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.update()
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.label).toBe('updated')
+    expect(result.current.state.$history.canUndo).toBe(true)
+    expect(result.current.state.$history.canRedo).toBe(false)
+
+    await act(async () => {
+      result.current.state.$history.undo()
+    })
+
+    expect(result.current.state.count).toBe(0)
+    expect(result.current.state.label).toBe('idle')
+    expect(result.current.state.$history.canUndo).toBe(false)
+    expect(result.current.state.$history.canRedo).toBe(true)
+
+    await act(async () => {
+      result.current.state.$history.redo()
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.label).toBe('updated')
+    expect(result.current.state.$history.canUndo).toBe(true)
+    expect(result.current.state.$history.canRedo).toBe(false)
+  })
+
+  test('restores array pushes without leaving sparse items', async () => {
+    const todo = model({ items: [] as string[] }, { history: true })
+    const todoActions = action(({ state }) => ({
+      add(item: string) {
+        state(todo).items.push(item)
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(todo),
+        actions: useAction<{ add: (item: string) => void }>([todoActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.add('buy milk')
+    })
+
+    expect(result.current.state.items).toEqual(['buy milk'])
+
+    await act(async () => {
+      result.current.state.$history.undo()
+    })
+
+    expect(result.current.state.items).toEqual([])
+    expect(result.current.state.items.length).toBe(0)
+
+    await act(async () => {
+      result.current.state.$history.redo()
+    })
+
+    expect(result.current.state.items).toEqual(['buy milk'])
+  })
+
+  test('clears redo stack when a new action is committed after undo', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      add(value: number) {
+        state(counter).count += value
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ add: (value: number) => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => result.current.actions.add(1))
+    await act(async () => result.current.actions.add(1))
+    expect(result.current.state.count).toBe(2)
+
+    await act(async () => result.current.state.$history.undo())
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.$history.canRedo).toBe(true)
+
+    await act(async () => result.current.actions.add(10))
+    expect(result.current.state.count).toBe(11)
+    expect(result.current.state.$history.canRedo).toBe(false)
+  })
+
+  test('supports ignore without suppressing rendering', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      setIgnored(value: number) {
+        const s = state(counter)
+        s.$history.ignore(() => {
+          s.count = value
+        })
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ setIgnored: (value: number) => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.setIgnored(5)
+    })
+
+    expect(result.current.state.count).toBe(5)
+    expect(result.current.state.$history.canUndo).toBe(false)
+  })
+
+  test('works through create() without adding a new hook', async () => {
+    const todo = model({ items: [] as string[] }, { history: true })
+    const todoActions = action(({ state }) => ({
+      add(item: string) {
+        state(todo).items.push(item)
+      },
+    }))
+    const useTodo = create(todo, { actions: [todoActions] })
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () =>
+        useTodo((s) => ({
+          items: s.items,
+          actions: s.actions,
+          history: s.$history,
+        })),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.add('ship history')
+    })
+
+    expect(result.current.items).toEqual(['ship history'])
+    expect(result.current.history.canUndo).toBe(true)
+
+    await act(async () => {
+      result.current.history.undo()
+    })
+
+    expect(result.current.items).toEqual([])
+    expect(result.current.history.canRedo).toBe(true)
+  })
+})

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -6,6 +6,7 @@ import {
   keepPreviousData,
   type BoundSingleResourceState,
 } from '../src/core/query'
+import { cancelModelGc, scheduleModelGc } from '../src/core/query/accessor'
 
 function deferred<T>() {
   let resolve!: (v: T) => void
@@ -18,6 +19,17 @@ function deferred<T>() {
 }
 
 function createBound<TData>(opts: {
+  initialData: TData
+  queryFn: (...args: any[]) => any
+  staleTime?: number
+  gcTime?: number
+  placeholderData?: any
+}) {
+  const result = createBoundWithRegistry(opts)
+  return result.bound
+}
+
+function createBoundWithRegistry<TData>(opts: {
   initialData: TData
   queryFn: (...args: any[]) => any
   staleTime?: number
@@ -39,9 +51,14 @@ function createBound<TData>(opts: {
     store.proxy,
     m.pluginBags.get('query')!,
     undefined,
-    registry
+    registry,
+    m.key
   ) as any
-  return bound.resource as BoundSingleResourceState<TData, any>
+  return {
+    bound: bound.resource as BoundSingleResourceState<TData, any>,
+    registry,
+    modelKey: m.key,
+  }
 }
 
 describe('query', () => {
@@ -208,7 +225,7 @@ describe('query', () => {
       expect(bound.data).toEqual(['result-a'])
     })
 
-    it('should clean up cache entries after gcTime on next query', async () => {
+    it('should keep cache entries while the model has active observers', async () => {
       const queryFn = vi
         .fn()
         .mockImplementation((arg: string) => Promise.resolve([`result-${arg}`]))
@@ -222,18 +239,84 @@ describe('query', () => {
       await bound.query('a')
       expect(queryFn).toHaveBeenCalledTimes(1)
 
-      // Simulate time passing beyond gcTime
-      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000)
+      // Time passing alone must NOT evict cache while observers are active.
+      // (Eviction is observer-driven now, not lastFetchedAt-driven.)
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 5_000)
 
-      // Query 'b' triggers cleanup of expired 'a'
       await bound.query('b')
       expect(queryFn).toHaveBeenCalledTimes(2)
 
-      // 'a' should have been gc'd, so querying 'a' again calls queryFn
       await bound.query('a')
-      expect(queryFn).toHaveBeenCalledTimes(3)
+      expect(queryFn).toHaveBeenCalledTimes(2)
+      expect(bound.data).toEqual(['result-a'])
 
       vi.restoreAllMocks()
+    })
+
+    it('should evict cache entries after gcTime once observers drop to 0', async () => {
+      vi.useFakeTimers()
+      const queryFn = vi
+        .fn()
+        .mockImplementation((arg: string) => Promise.resolve([`result-${arg}`]))
+      const { bound, registry, modelKey } = createBoundWithRegistry({
+        initialData: [] as string[],
+        queryFn,
+        staleTime: 10_000,
+        gcTime: 500,
+      })
+
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Simulate the last observer unmounting.
+      scheduleModelGc(registry, modelKey)
+
+      // Before gcTime elapses, the entry is still around — a refetch with a
+      // new observer is satisfied from cache.
+      await vi.advanceTimersByTimeAsync(400)
+      cancelModelGc(registry, modelKey)
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Unmount again, this time let the timer fire fully.
+      scheduleModelGc(registry, modelKey)
+      await vi.advanceTimersByTimeAsync(600)
+
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+    })
+
+    it('should default gcTime to 5 minutes when not configured', async () => {
+      vi.useFakeTimers()
+      const queryFn = vi.fn().mockResolvedValue(['alice'])
+      const { bound, registry, modelKey } = createBoundWithRegistry({
+        initialData: [] as string[],
+        queryFn,
+        // Use a staleTime large enough that staleness can't trigger refetches
+        // during the time advances below — we want to isolate GC behavior.
+        staleTime: 60 * 60_000,
+      })
+
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      scheduleModelGc(registry, modelKey)
+
+      // Just shy of 5 minutes: still cached.
+      await vi.advanceTimersByTimeAsync(5 * 60_000 - 100)
+      cancelModelGc(registry, modelKey)
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Past 5 minutes: evicted.
+      scheduleModelGc(registry, modelKey)
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 100)
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
     })
   })
 

--- a/packages/comwit/tests/snapshot-types.test.ts
+++ b/packages/comwit/tests/snapshot-types.test.ts
@@ -80,3 +80,17 @@ test('action state() — standalone snapshot() converts nested slices', () => {
     return {}
   })
 })
+
+test('history-enabled models expose $history methods', () => {
+  const m = model({ count: 0 }, { history: true })
+
+  action(({ state }) => {
+    const s = state(m)
+    expectTypeOf(s.$history.canUndo).toEqualTypeOf<boolean>()
+    expectTypeOf(s.$history.undo).toBeFunction()
+    expectTypeOf(s.$history.redo).toBeFunction()
+    s.$history.undo()
+    s.$history.redo()
+    return {}
+  })
+})


### PR DESCRIPTION
## Summary
- add opt-in model history via `history: true` / `history: { limit }`
- expose undo/redo through `s.` without adding a new hook
- record each action method call as one history transaction using proxy op/inverse-op patches
- document `` usage in API docs and LLM references

## Tests
- `yarn workspace comwit typecheck`
- `yarn workspace comwit test`
- `yarn workspace comwit build`