### PR TITLE
feat!: observer-based gcTime, drop cacheTime alias (v2.0.0-beta)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /pnpm-lock.yaml
 /yarn-error.log
 /.worktree
+/.claude

--- a/apps/docs/content/docs/api/persist.mdx
+++ b/apps/docs/content/docs/api/persist.mdx
@@ -35,13 +35,13 @@ export type SettingsState = {
 
 ## Options
 
-| Option        | Type                                                    | Description                                        |
-| ------------- | ------------------------------------------------------- | -------------------------------------------------- |
-| `key`         | `string`                                                | **Required.** Storage key.                         |
-| `defaultValue`| `T`                                                     | **Required.** Value when storage is empty.         |
-| `storage`     | `'localStorage' \| 'sessionStorage' \| PersistAdapter`  | Storage backend. Default `'localStorage'`.         |
-| `serialize`   | `(value: T) => string`                                  | Custom serializer. Default `JSON.stringify`.       |
-| `deserialize` | `(raw: string) => T`                                    | Custom deserializer. Default `JSON.parse`.         |
+| Option         | Type                                                   | Description                                  |
+| -------------- | ------------------------------------------------------ | -------------------------------------------- |
+| `key`          | `string`                                               | **Required.** Storage key.                   |
+| `defaultValue` | `T`                                                    | **Required.** Value when storage is empty.   |
+| `storage`      | `'localStorage' \| 'sessionStorage' \| PersistAdapter` | Storage backend. Default `'localStorage'`.   |
+| `serialize`    | `(value: T) => string`                                 | Custom serializer. Default `JSON.stringify`. |
+| `deserialize`  | `(raw: string) => T`                                   | Custom deserializer. Default `JSON.parse`.   |
 
 ## How it works
 
@@ -70,12 +70,20 @@ Implement `PersistAdapter<T>` for custom storage backends:
 import { type PersistAdapter } from 'comwit'
 
 const indexedDBAdapter: PersistAdapter<UserPrefs> = {
-  get(key) { /* read from IndexedDB */ },
-  set(key, value) { /* write to IndexedDB */ },
-  remove(key) { /* delete from IndexedDB */ },
+  get(key) {
+    /* read from IndexedDB */
+  },
+  set(key, value) {
+    /* write to IndexedDB */
+  },
+  remove(key) {
+    /* delete from IndexedDB */
+  },
   subscribe(key, callback) {
     // optional: listen for external changes
-    return () => { /* cleanup */ }
+    return () => {
+      /* cleanup */
+    }
   },
 }
 

--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -62,17 +62,16 @@ Once accessed via `state()` in an action, query fields expose these methods:
 
 Pass options at the query definition or globally via `ComwitProvider`:
 
-| Option            | Description                                                                    |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `staleTime`       | Time in ms before cached data is considered stale (default: 0)                 |
-| `cacheTime`       | Alias for gcTime                                                               |
-| `gcTime`          | Time in ms before unused cache entries are garbage collected                   |
-| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results. |
-| `force`           | Skip cache and always fetch (call-time only)                                   |
-| `enabled`         | `(state) => boolean` — skip query when condition is false                      |
-| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved             |
-| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval    |
-| `suspense`        | `boolean` — enable React Suspense integration                                  |
+| Option            | Description                                                                                      |
+| ----------------- | ------------------------------------------------------------------------------------------------ |
+| `staleTime`       | Time in ms before cached data is considered stale (default: 0)                                   |
+| `gcTime`          | Time in ms a cache entry survives after the model loses its last observer (default: 5 \* 60_000) |
+| `placeholderData` | Data to show while loading. Use `keepPreviousData` to retain previous results.                   |
+| `force`           | Skip cache and always fetch (call-time only)                                                     |
+| `enabled`         | `(state) => boolean` — skip query when condition is false                                        |
+| `dependsOn`       | `(state) => any` — block query until dependency is truthy/resolved                               |
+| `refetchInterval` | `number \| false \| (data, error?) => number \| false` — auto-poll interval                      |
+| `suspense`        | `boolean` — enable React Suspense integration                                                    |
 
 ## queryFn context
 

--- a/apps/docs/content/docs/guide/quickstart.mdx
+++ b/apps/docs/content/docs/guide/quickstart.mdx
@@ -41,8 +41,7 @@ export function Providers({ children }: { children: ReactNode }) {
       defaultOptions={{
         query: {
           staleTime: 30_000,
-          cacheTime: 120_000,
-          gcTime: 180_000,
+          gcTime: 5 * 60_000,
           placeholderData: keepPreviousData,
         },
         persist: {
@@ -91,7 +90,7 @@ import { OnError, Log, ComwitProvider } from 'comwit'
 `ComwitProvider` takes two props:
 
 - **context** — shared values (router, auth, etc.) available in all actions
-- **defaultOptions.query** — global query defaults (staleTime, cacheTime, placeholderData)
+- **defaultOptions.query** — global query defaults (staleTime, gcTime, placeholderData)
 - **defaultOptions.persist** — global persist defaults (debounceMs)
 - **defaultOptions.interceptors** — global interceptors applied to all action methods
 

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -29,8 +29,7 @@ export const post = model<PostState>({
 | `queryFn`         | `(arg, context) => TData \| Promise<TData>` | **Required.** Fetcher function.                                      |
 | `suspense`        | `boolean`                                   | Enable React Suspense integration. Default `false`.                  |
 | `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0`.    |
-| `cacheTime`       | `number`                                    | Alias for `gcTime`. Milliseconds before cache entry is garbage collected. |
-| `gcTime`          | `number`                                    | Milliseconds before cache entry is garbage collected.                |
+| `gcTime`          | `number`                                    | Milliseconds a cache entry survives after the model loses its last observer. Default `5 * 60_000`. |
 | `placeholderData` | `TData \| (arg, previousData) => TData`     | Data shown while fetching. Use `keepPreviousData` helper.            |
 
 ### queryFn Signature
@@ -223,7 +222,7 @@ await this.model.comments.query(postId, { staleTime: 60_000 })
 
 **Options:**
 - `force: boolean` — Bypass cache staleness check and always fetch.
-- `staleTime`, `cacheTime`, `gcTime`, `placeholderData` — Override defaults per call.
+- `staleTime`, `gcTime`, `placeholderData` — Override defaults per call.
 
 ### .refetch()
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -52,8 +52,7 @@ export function Providers({ children }: { children: ReactNode }) {
       defaultOptions={{
         query: {
           staleTime: 30_000,
-          cacheTime: 120_000,
-          gcTime: 180_000,
+          gcTime: 5 * 60_000,
           placeholderData: keepPreviousData,
         },
       }}
@@ -297,7 +296,7 @@ export const usePost = create<PostState, PostActions>(post, {
 - Realtime methods: `.query()` · `.refetch()` · `.set()` · `.unsubscribe()`
 - Realtime-only: `connectionStatus` · `isConnected`
 - Subscribe callbacks: `update` · `set` · `refetch` · `onStatus` · `onError`
-- Options: `staleTime` · `cacheTime` · `gcTime` · `placeholderData` · `force`
+- Options: `staleTime` · `gcTime` · `placeholderData` · `force`
 - Suspense: `Query.Suspense<T>` · `Query.SuspenseInfinite<T>` · `{ suspense: true }`
 
 For full API details, see the [Query System Reference](/llm/query.txt).

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.0.0",
+  "version": "2.0.0-beta.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -11,7 +11,8 @@
     "url": "https://github.com/meursyphus/comwit/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   },
   "type": "module",
   "description": "React state management for vibe coding. Less tokens. Built for Claude Code.",

--- a/packages/comwit/src/core/action.ts
+++ b/packages/comwit/src/core/action.ts
@@ -55,7 +55,8 @@ export function useAction<A, C extends object = Record<string, never>>(
           proxy,
           bag,
           registryState,
-          defaults as Record<string, unknown> | undefined
+          defaults as Record<string, unknown> | undefined,
+          dep.key
         )
       }
 

--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -179,21 +179,27 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
   const subscribe = useCallback(
     (listener: () => void) => {
       lifecycle.subscriberCount++
-      if (lifecycle.subscriberCount === 1 && m.onObserve) {
-        const result = m.onObserve(store.proxy)
-        lifecycle.cleanup = typeof result === 'function' ? result : null
+      if (lifecycle.subscriberCount === 1) {
+        notifySubscriberChange(m, registry, true)
+        if (m.onObserve) {
+          const result = m.onObserve(store.proxy)
+          lifecycle.cleanup = typeof result === 'function' ? result : null
+        }
       }
       const unsubProxy = store.subscribe(listener)
       return () => {
         unsubProxy()
         lifecycle.subscriberCount--
-        if (lifecycle.subscriberCount === 0 && lifecycle.cleanup) {
-          lifecycle.cleanup()
-          lifecycle.cleanup = null
+        if (lifecycle.subscriberCount === 0) {
+          if (lifecycle.cleanup) {
+            lifecycle.cleanup()
+            lifecycle.cleanup = null
+          }
+          notifySubscriberChange(m, registry, false)
         }
       }
     },
-    [store, lifecycle, m]
+    [store, lifecycle, m, registry]
   )
 
   const getSnapshot = useCallback(() => {
@@ -221,6 +227,21 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
   }
 
   return result
+}
+
+function notifySubscriberChange(
+  m: Model<any>,
+  registry: ReturnType<typeof useStoreRegistry>,
+  hasObservers: boolean
+): void {
+  const plugins = getPlugins()
+  for (const plugin of plugins) {
+    if (!plugin.onSubscriberChange) continue
+    const bag = m.pluginBags.get(plugin.name)
+    if (!bag || bag.size === 0) continue
+    const registryState = registry.pluginStates.get(plugin.name)
+    plugin.onSubscriberChange(m.key, bag, registryState, hasObservers)
+  }
 }
 
 function normalize(value: unknown, path: string, pluginBags: Map<string, PluginBag>): unknown {

--- a/packages/comwit/src/core/plugin.ts
+++ b/packages/comwit/src/core/plugin.ts
@@ -29,12 +29,15 @@ export type FieldPlugin = {
   /**
    * Called when action's state() binds a model proxy.
    * Wraps the proxy with plugin-specific accessors (e.g. .query(), .refetch()).
+   * `modelKey` identifies the owning model; plugins that track per-model
+   * runtime state should index by it.
    */
   bindState(
     proxy: object,
     bag: PluginBag,
     registryState: unknown,
-    defaults?: Record<string, unknown>
+    defaults?: Record<string, unknown>,
+    modelKey?: symbol
   ): object
 
   /**
@@ -42,6 +45,19 @@ export type FieldPlugin = {
    * Used by query plugin to throw promises for Suspense or errors for ErrorBoundary.
    */
   onRender?(bag: PluginBag, registryState: unknown): void
+
+  /**
+   * Called when a model's observer count transitions to/from 0.
+   * Fires with `hasObservers=true` when count goes 0→1, and
+   * `hasObservers=false` when count goes 1→0. Used by the query plugin
+   * to schedule/cancel cache eviction (TanStack-style gcTime).
+   */
+  onSubscriberChange?(
+    modelKey: symbol,
+    bag: PluginBag,
+    registryState: unknown,
+    hasObservers: boolean
+  ): void
 }
 
 const plugins: FieldPlugin[] = []

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -1,4 +1,5 @@
 import { snapshot } from '../proxy'
+import { DEFAULT_GC_TIME } from './registry'
 import {
   RESOURCE_QUERY_OPTION_KEYS,
   type AnyResourceDescriptor,
@@ -42,10 +43,9 @@ function normalizeError(error: unknown) {
   return 'Unknown error'
 }
 
-function resolveGcTime(options: QueryDefaultOptions): number | undefined {
-  if (typeof options.cacheTime === 'number') return options.cacheTime
+function resolveGcTime(options: QueryDefaultOptions): number {
   if (typeof options.gcTime === 'number') return options.gcTime
-  return undefined
+  return DEFAULT_GC_TIME
 }
 
 export function mergeResult(state: ResourceDataLike, result: unknown, appendData = false) {
@@ -162,14 +162,15 @@ function cloneRuntime(path: string): ResourceRuntimeState {
     activeKey: undefined,
     fetchId: 0,
     cacheEntries: new Map(),
+    gcTime: DEFAULT_GC_TIME,
+    gcTimers: new Map(),
   }
 }
 
 function createCacheEntry(
   state: ResourceDataLike,
   key: QueryCacheKey,
-  arg: unknown,
-  gcTime?: number
+  arg: unknown
 ): QueryCacheEntry {
   return {
     key,
@@ -177,7 +178,6 @@ function createCacheEntry(
     hasQueried: false,
     lastFetchedAt: 0,
     cursorHistory: [],
-    gcTime,
     state: snapshot(state) as ResourceDataLike,
   }
 }
@@ -192,17 +192,44 @@ function updateCachedState(entry: QueryCacheEntry, source: ResourceDataLike) {
   entry.state = snapshot(source) as ResourceDataLike
 }
 
-function cleanupExpiredCacheEntries(runtime: ResourceRuntimeState, now: number) {
-  for (const [key, entry] of runtime.cacheEntries) {
-    if (typeof entry.gcTime !== 'number') continue
-    if (entry.lastFetchedAt === 0) continue
-    if (now - entry.lastFetchedAt < entry.gcTime) continue
-
-    runtime.cacheEntries.delete(key)
-    if (runtime.activeKey === key) {
-      runtime.activeKey = undefined
-      runtime.lastArg = undefined
+/**
+ * Schedules eviction for every cache entry on every runtime owned by the
+ * given model key. Called by the query plugin when the model's observer
+ * count transitions to 0. Subsequent calls are idempotent — existing
+ * timers are left in place.
+ */
+export function scheduleModelGc(registry: QueryBindingRegistry, modelKey: symbol) {
+  const runtimes = registry.runtimesByModel.get(modelKey)
+  if (!runtimes) return
+  for (const runtime of runtimes) {
+    for (const [key] of runtime.cacheEntries) {
+      if (runtime.gcTimers.has(key)) continue
+      const timer = setTimeout(() => {
+        runtime.gcTimers.delete(key)
+        runtime.cacheEntries.delete(key)
+        if (runtime.activeKey === key) {
+          runtime.activeKey = undefined
+          runtime.lastArg = undefined
+        }
+      }, runtime.gcTime)
+      runtime.gcTimers.set(key, timer)
     }
+  }
+}
+
+/**
+ * Cancels all pending GC timers across every runtime owned by the model.
+ * Called by the query plugin when the model gains its first observer
+ * (subscriber count transitions from 0 to 1).
+ */
+export function cancelModelGc(registry: QueryBindingRegistry, modelKey: symbol) {
+  const runtimes = registry.runtimesByModel.get(modelKey)
+  if (!runtimes) return
+  for (const runtime of runtimes) {
+    for (const timer of runtime.gcTimers.values()) {
+      clearTimeout(timer)
+    }
+    runtime.gcTimers.clear()
   }
 }
 
@@ -254,7 +281,8 @@ export function createResourceAccessor(
   path: string,
   defaults: QueryDefaultOptions | undefined,
   registry: QueryBindingRegistry,
-  modelState?: object
+  modelState?: object,
+  modelKey?: symbol
 ): ResourceDataLike {
   if (registry.boundResourceValue.has(state)) {
     return registry.boundResourceValue.get(state) as ResourceDataLike
@@ -262,7 +290,20 @@ export function createResourceAccessor(
 
   const runtime = registry.boundResourceRuntime.get(state) ?? cloneRuntime(path)
   runtime.path = path
+  runtime.gcTime = resolveGcTime({
+    ...(defaults ?? {}),
+    ...(descriptor.options as QueryDefaultOptions),
+  })
   registry.boundResourceRuntime.set(state, runtime)
+
+  if (modelKey !== undefined) {
+    let set = registry.runtimesByModel.get(modelKey)
+    if (!set) {
+      set = new Set()
+      registry.runtimesByModel.set(modelKey, set)
+    }
+    set.add(runtime)
+  }
 
   const getActiveEntry = () => {
     if (!runtime.activeKey) return
@@ -350,9 +391,8 @@ export function createResourceAccessor(
 
     const staleTime =
       typeof effectiveOptions.staleTime === 'number' ? effectiveOptions.staleTime : 0
-    const gcTime = resolveGcTime(effectiveOptions)
+    runtime.gcTime = resolveGcTime(effectiveOptions)
     const now = Date.now()
-    cleanupExpiredCacheEntries(runtime, now)
 
     const queryArg = isRefetch ? activeEntryBefore?.arg : hasArg ? arg : runtime.lastArg
     const queryKey = serializeQueryArg(queryArg)
@@ -361,11 +401,16 @@ export function createResourceAccessor(
 
     let entry = runtime.cacheEntries.get(queryKey)
     if (!entry) {
-      entry = createCacheEntry(state, queryKey, queryArg, gcTime)
+      entry = createCacheEntry(state, queryKey, queryArg)
       runtime.cacheEntries.set(queryKey, entry)
+    } else {
+      const pending = runtime.gcTimers.get(queryKey)
+      if (pending !== undefined) {
+        clearTimeout(pending)
+        runtime.gcTimers.delete(queryKey)
+      }
     }
 
-    entry.gcTime = gcTime
     entry.arg = queryArg
 
     const shouldFetch =

--- a/packages/comwit/src/core/query/bind.ts
+++ b/packages/comwit/src/core/query/bind.ts
@@ -31,7 +31,8 @@ function bindPath(
   path = '',
   defaults: QueryDefaultOptions | undefined,
   registry: QueryBindingRegistry,
-  modelState?: object
+  modelState?: object,
+  modelKey?: symbol
 ): any {
   if (!descriptors.size) return state
 
@@ -57,12 +58,13 @@ function bindPath(
           nextPath,
           defaults,
           registry,
-          modelState
+          modelState,
+          modelKey
         )
       }
 
       if (isRecord(next) && hasNestedPath(descriptors, nextPath)) {
-        return bindPath(next, descriptors, nextPath, defaults, registry, modelState)
+        return bindPath(next, descriptors, nextPath, defaults, registry, modelState, modelKey)
       }
 
       return next
@@ -80,8 +82,17 @@ export function bindResourceState<T extends object>(
   modelState: T,
   resourceDescriptors: ResourceDescriptorMap,
   defaults?: QueryDefaultOptions,
-  registry: QueryBindingRegistry = createQueryBindingRegistry()
+  registry: QueryBindingRegistry = createQueryBindingRegistry(),
+  modelKey?: symbol
 ): T {
   if (!resourceDescriptors.size) return modelState
-  return bindPath(modelState, resourceDescriptors, '', defaults, registry, modelState) as T
+  return bindPath(
+    modelState,
+    resourceDescriptors,
+    '',
+    defaults,
+    registry,
+    modelState,
+    modelKey
+  ) as T
 }

--- a/packages/comwit/src/core/query/plugin.ts
+++ b/packages/comwit/src/core/query/plugin.ts
@@ -1,6 +1,7 @@
 import { registerPlugin, type FieldPlugin, type PluginBag } from '../plugin'
 import { isResourceDescriptor } from './descriptor'
 import { bindResourceState } from './bind'
+import { cancelModelGc, scheduleModelGc } from './accessor'
 import { checkSuspense } from './suspense'
 import { createQueryBindingRegistry } from './registry'
 import type {
@@ -30,7 +31,8 @@ export const queryPlugin: FieldPlugin = {
     proxy: object,
     bag: PluginBag,
     registryState: unknown,
-    defaults?: Record<string, unknown>
+    defaults?: Record<string, unknown>,
+    modelKey?: symbol
   ): object {
     if (bag.size === 0) return proxy
     const descriptors = bag as ResourceDescriptorMap
@@ -38,7 +40,8 @@ export const queryPlugin: FieldPlugin = {
       proxy as any,
       descriptors,
       defaults as QueryDefaultOptions | undefined,
-      registryState as QueryBindingRegistry
+      registryState as QueryBindingRegistry,
+      modelKey
     )
   },
 
@@ -46,6 +49,20 @@ export const queryPlugin: FieldPlugin = {
     if (bag.size === 0) return
     const descriptors = bag as ResourceDescriptorMap
     checkSuspense(descriptors, registryState as QueryBindingRegistry)
+  },
+
+  onSubscriberChange(
+    modelKey: symbol,
+    _bag: PluginBag,
+    registryState: unknown,
+    hasObservers: boolean
+  ): void {
+    const registry = registryState as QueryBindingRegistry
+    if (hasObservers) {
+      cancelModelGc(registry, modelKey)
+    } else {
+      scheduleModelGc(registry, modelKey)
+    }
   },
 }
 

--- a/packages/comwit/src/core/query/registry.ts
+++ b/packages/comwit/src/core/query/registry.ts
@@ -1,10 +1,17 @@
 import type { QueryBindingRegistry } from './types'
 
+/**
+ * Default time (ms) a cache entry survives after the owning model loses
+ * its last observer. Mirrors TanStack Query v5's `gcTime` default.
+ */
+export const DEFAULT_GC_TIME = 5 * 60 * 1000
+
 export function createQueryBindingRegistry(): QueryBindingRegistry {
   return {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
     boundResourceRuntime: new WeakMap(),
     suspense: new Map(),
+    runtimesByModel: new Map(),
   }
 }

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -21,13 +21,11 @@ export const RESOURCE_QUERY_OPTION_KEYS = new Set([
   'force',
   'placeholderData',
   'staleTime',
-  'cacheTime',
   'gcTime',
 ])
 
 export type QueryDefaultOptions = {
   staleTime?: number
-  cacheTime?: number
   gcTime?: number
   placeholderData?: PlaceholderData<unknown, unknown>
 }
@@ -295,7 +293,6 @@ export type QueryCacheEntry = {
   lastFetchedAt: number
   lastResult?: unknown
   cursorHistory: Array<string | null>
-  gcTime?: number
   state: ResourceDataLike
 }
 
@@ -309,6 +306,12 @@ export type QueryBindingRegistry = {
   boundPathProxy: WeakMap<object, Map<string, object>>
   boundResourceRuntime: WeakMap<object, ResourceRuntimeState>
   suspense: Map<string, SuspenseState>
+  /**
+   * Tracks every runtime created in this registry, indexed by the owning
+   * model's key. Used by the GC scheduler to enumerate which cache entries
+   * belong to a model when its observer count transitions to 0.
+   */
+  runtimesByModel: Map<symbol, Set<ResourceRuntimeState>>
 }
 
 export type ResourceRuntimeState = {
@@ -320,4 +323,16 @@ export type ResourceRuntimeState = {
   subscriptionCleanup?: () => void
   refetchIntervalId?: ReturnType<typeof setInterval>
   streamAbortController?: AbortController
+  /**
+   * Configured gcTime for this runtime, resolved at bind time from
+   * descriptor options + provider defaults. Used when scheduling eviction
+   * after the owning model loses its last observer.
+   */
+  gcTime: number
+  /**
+   * Pending eviction timers keyed by cache entry key. Populated when the
+   * owning model's observer count drops to 0 and cleared when it rises
+   * back to >=1.
+   */
+  gcTimers: Map<QueryCacheKey, ReturnType<typeof setTimeout>>
 }

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -6,6 +6,7 @@ import {
   keepPreviousData,
   type BoundSingleResourceState,
 } from '../src/core/query'
+import { cancelModelGc, scheduleModelGc } from '../src/core/query/accessor'
 
 function deferred<T>() {
   let resolve!: (v: T) => void
@@ -18,6 +19,17 @@ function deferred<T>() {
 }
 
 function createBound<TData>(opts: {
+  initialData: TData
+  queryFn: (...args: any[]) => any
+  staleTime?: number
+  gcTime?: number
+  placeholderData?: any
+}) {
+  const result = createBoundWithRegistry(opts)
+  return result.bound
+}
+
+function createBoundWithRegistry<TData>(opts: {
   initialData: TData
   queryFn: (...args: any[]) => any
   staleTime?: number
@@ -39,9 +51,14 @@ function createBound<TData>(opts: {
     store.proxy,
     m.pluginBags.get('query')!,
     undefined,
-    registry
+    registry,
+    m.key
   ) as any
-  return bound.resource as BoundSingleResourceState<TData, any>
+  return {
+    bound: bound.resource as BoundSingleResourceState<TData, any>,
+    registry,
+    modelKey: m.key,
+  }
 }
 
 describe('query', () => {
@@ -208,7 +225,7 @@ describe('query', () => {
       expect(bound.data).toEqual(['result-a'])
     })
 
-    it('should clean up cache entries after gcTime on next query', async () => {
+    it('should keep cache entries while the model has active observers', async () => {
       const queryFn = vi
         .fn()
         .mockImplementation((arg: string) => Promise.resolve([`result-${arg}`]))
@@ -222,18 +239,84 @@ describe('query', () => {
       await bound.query('a')
       expect(queryFn).toHaveBeenCalledTimes(1)
 
-      // Simulate time passing beyond gcTime
-      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000)
+      // Time passing alone must NOT evict cache while observers are active.
+      // (Eviction is observer-driven now, not lastFetchedAt-driven.)
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 5_000)
 
-      // Query 'b' triggers cleanup of expired 'a'
       await bound.query('b')
       expect(queryFn).toHaveBeenCalledTimes(2)
 
-      // 'a' should have been gc'd, so querying 'a' again calls queryFn
       await bound.query('a')
-      expect(queryFn).toHaveBeenCalledTimes(3)
+      expect(queryFn).toHaveBeenCalledTimes(2)
+      expect(bound.data).toEqual(['result-a'])
 
       vi.restoreAllMocks()
+    })
+
+    it('should evict cache entries after gcTime once observers drop to 0', async () => {
+      vi.useFakeTimers()
+      const queryFn = vi
+        .fn()
+        .mockImplementation((arg: string) => Promise.resolve([`result-${arg}`]))
+      const { bound, registry, modelKey } = createBoundWithRegistry({
+        initialData: [] as string[],
+        queryFn,
+        staleTime: 10_000,
+        gcTime: 500,
+      })
+
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Simulate the last observer unmounting.
+      scheduleModelGc(registry, modelKey)
+
+      // Before gcTime elapses, the entry is still around — a refetch with a
+      // new observer is satisfied from cache.
+      await vi.advanceTimersByTimeAsync(400)
+      cancelModelGc(registry, modelKey)
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Unmount again, this time let the timer fire fully.
+      scheduleModelGc(registry, modelKey)
+      await vi.advanceTimersByTimeAsync(600)
+
+      await bound.query('a')
+      expect(queryFn).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
+    })
+
+    it('should default gcTime to 5 minutes when not configured', async () => {
+      vi.useFakeTimers()
+      const queryFn = vi.fn().mockResolvedValue(['alice'])
+      const { bound, registry, modelKey } = createBoundWithRegistry({
+        initialData: [] as string[],
+        queryFn,
+        // Use a staleTime large enough that staleness can't trigger refetches
+        // during the time advances below — we want to isolate GC behavior.
+        staleTime: 60 * 60_000,
+      })
+
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      scheduleModelGc(registry, modelKey)
+
+      // Just shy of 5 minutes: still cached.
+      await vi.advanceTimersByTimeAsync(5 * 60_000 - 100)
+      cancelModelGc(registry, modelKey)
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(1)
+
+      // Past 5 minutes: evicted.
+      scheduleModelGc(registry, modelKey)
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 100)
+      await bound.query()
+      expect(queryFn).toHaveBeenCalledTimes(2)
+
+      vi.useRealTimers()
     })
   })
 


### PR DESCRIPTION
> **Re-targeted.** Original PR #73 was squash-merged into the wrong long-running branch by accident. This PR is the same change re-opened against the new `v2` integration branch.

## Summary

- **\`gcTime\` now follows TanStack Query v5 semantics.** The eviction timer starts the moment a model's last \`useModel\` observer unmounts; while subscribers are attached, cache entries are never evicted. This fixes the original symptom where small \`gcTime\`/\`cacheTime\` values caused \`isLoading\` to flicker on a same-key refetch.
- **Drop \`cacheTime\` alias.** It used to fall through to \`gcTime\`. The option is removed entirely — use \`gcTime\`.
- **Default \`gcTime\` is now \`5 * 60_000\`** (5 min), matching TanStack defaults.
- **Package shipped as \`2.0.0-beta.0\` on the \`beta\` dist-tag** so \`npm i comwit\` keeps resolving the 1.x stable line.

## Why

When \`gcTime\` was set low (or \`cacheTime: 0\`), \`cleanupExpiredCacheEntries\` ran on every \`executeQuery\` call and would evict the active cache entry between two consecutive queries of the same key. The next call then re-entered the \`isArgChange\` branch (\`activeEntryBefore.hasQueried === true && new entry.hasQueried === false\`), which reset state to \`descriptor.initialState\` and set \`isLoading = true\`. End result: a same-key refetch behaved like a cold start.

TanStack avoids this by gating GC on observer count rather than \`lastFetchedAt\`. This PR adopts the same model.

## How it works

- \`LifecycleState.subscriberCount\` (already maintained by \`useModel\`'s \`useSyncExternalStore\` subscribe callback) drives the new behavior.
- \`FieldPlugin\` gains an optional \`onSubscriberChange(modelKey, bag, registryState, hasObservers)\` hook. \`model.ts\` fires it on 0→1 and 1→0 transitions.
- The query plugin implements that hook: on \`hasObservers=false\` it schedules a \`setTimeout(evict, runtime.gcTime)\` per cache entry across every runtime owned by the model; on \`hasObservers=true\` it clears all pending timers.
- \`createResourceAccessor\` now registers each runtime into \`QueryBindingRegistry.runtimesByModel: Map<symbol, Set<runtime>>\` indexed by \`Model.key\`.
- The eager \`cleanupExpiredCacheEntries\` call and \`entry.gcTime\` field are removed.

## Breaking changes

| Change | Migration |
| --- | --- |
| \`cacheTime\` option removed | Rename to \`gcTime\` |
| \`gcTime\` default \`undefined → 5 * 60_000\` | If you relied on "never GC," pass \`gcTime: Infinity\` |
| Eager time-based eviction is gone | Long-lived models keep cache entries; rely on \`staleTime\` for refetch cadence |
| \`FieldPlugin.bindState\` gains optional \`modelKey: symbol\` arg | External plugins accept or ignore the extra arg |
| New optional \`FieldPlugin.onSubscriberChange\` hook | Optional — no migration needed if not implemented |

## Test plan

- [x] \`yarn workspace comwit typecheck\`
- [x] \`yarn test\` — 306/306 passing
- [x] \`yarn workspace comwit build\` — clean
- [x] New unit tests cover: (a) same-key refetch keeps cache during active subscription, (b) eviction fires \`gcTime\` ms after subscriber count drops to 0, (c) default \`gcTime\` is \`5 * 60_000\`.
- [ ] Smoke-test the playground app after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)