### PR TITLE
feat: add model history (undo/redo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /pnpm-lock.yaml
 /yarn-error.log
 /.worktree
+/.claude

--- a/apps/docs/content/docs/api/action.mdx
+++ b/apps/docs/content/docs/api/action.mdx
@@ -57,6 +57,8 @@ The factory receives `{ state, context }`:
 - **state(model)** — returns a mutable proxy to a model's state. Call it for each model you need.
 - **context** — the shared context from `ComwitProvider` (router, auth, etc.)
 
+When a model has [`history: true`](/docs/api/history), each action method call is recorded as one history transaction. Multiple state mutations inside the method are undone together via `state.$history.undo()`.
+
 ## Class pattern
 
 Use a class inside the factory. This gives you:

--- a/apps/docs/content/docs/api/history.mdx
+++ b/apps/docs/content/docs/api/history.mdx
@@ -93,8 +93,8 @@ const editor = model(
 ```
 
 - `history: false` or omitted — no `$history` field, no history tracking
-- `history: true` — enable history with no stack limit
-- `history: { limit }` — keep at most `limit` undo entries
+- `history: true` — enable history with the default limit of 100 undo entries
+- `history: { limit }` — enable history and override the undo stack limit
 
 ## Ignoring Changes
 

--- a/apps/docs/content/docs/api/history.mdx
+++ b/apps/docs/content/docs/api/history.mdx
@@ -1,0 +1,136 @@
+---
+title: '$history'
+group: 'API'
+slug: 'api/history'
+order: 8
+---
+
+# $history
+
+Undo and redo for model state. History is disabled by default and only exists on models that opt in.
+
+```ts
+import { model } from 'comwit'
+
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: true,
+  }
+)
+```
+
+## Usage
+
+No new hook is required. Read and call `$history` from the existing hook created by [`create()`](/docs/api/create).
+
+```tsx
+const { items, history } = useTodo((s) => ({
+  items: s.items,
+  history: s.$history,
+}))
+
+return (
+  <div>
+    <button onClick={() => history.undo()} disabled={!history.canUndo}>
+      Undo
+    </button>
+    <button onClick={() => history.redo()} disabled={!history.canRedo}>
+      Redo
+    </button>
+  </div>
+)
+```
+
+## Recording
+
+Each action method call is recorded as one history transaction.
+
+```ts
+const todoActions = action(({ state }) => ({
+  add(title: string) {
+    const s = state(todo)
+    s.items.push({ id: crypto.randomUUID(), title, done: false })
+    s.selectedId = s.items.at(-1)!.id
+  },
+}))
+```
+
+The two mutations above are undone together by one call to `s.$history.undo()`.
+
+## API
+
+```ts
+type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+```
+
+## Options
+
+```ts
+const editor = model(
+  { blocks: [] as Block[] },
+  {
+    history: {
+      limit: 100,
+    },
+  }
+)
+```
+
+- `history: false` or omitted — no `$history` field, no history tracking
+- `history: true` — enable history with no stack limit
+- `history: { limit }` — keep at most `limit` undo entries
+
+## Ignoring Changes
+
+Use `$history.ignore()` for state changes that should re-render but should not be undoable.
+
+```ts
+const editorActions = action(({ state }) => ({
+  setDraft(value: string) {
+    const s = state(editor)
+    s.$history.ignore(() => {
+      s.draft = value
+    })
+  },
+}))
+```
+
+This is different from [`silent()`](/docs/api/silent). `silent()` suppresses notifications for hydration-style writes. `$history.ignore()` only skips history recording.
+
+## Manual Transactions
+
+Action methods are already transactions. Use `$history.transaction()` only when you need to group nested or manual changes explicitly.
+
+```ts
+const editorActions = action(({ state }) => ({
+  bulkRename(ids: string[], title: string) {
+    const s = state(editor)
+    s.$history.transaction('bulk rename', () => {
+      for (const id of ids) {
+        const block = s.blocks.find((x) => x.id === id)
+        if (block) block.title = title
+      }
+    })
+  },
+}))
+```
+
+## Redo Stack
+
+When a new action is committed after an undo, the redo stack is cleared. This follows the standard undo/redo model used by editors and state history systems.

--- a/apps/docs/content/docs/api/model.mdx
+++ b/apps/docs/content/docs/api/model.mdx
@@ -50,6 +50,7 @@ export const app = model<AppState>({
 - Fields using [`query()`](/docs/api/query) become client-fetched data with loading states
 - Fields using [`persist()`](/docs/api/persist) are automatically synced to storage
 - Plain fields (strings, objects, arrays, null) are reactive local state
+- Models with `history: true` expose [`$history`](/docs/api/history) for undo and redo
 - Models initialize lazily — only when first accessed via a hook
 - Each model instance is scoped to the nearest `ComwitProvider`
 
@@ -152,6 +153,37 @@ const chat = model(
 - Initializing analytics or logging
 - Subscribing to external event sources
 
+## History
+
+History is disabled by default. Enable it per model when user-facing changes should support undo and redo.
+
+```ts
+const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: {
+      limit: 100,
+    },
+  }
+)
+```
+
+No new hook is needed. Access `$history` through the existing hook from [`create()`](/docs/api/create).
+
+```tsx
+const history = useTodo((s) => s.$history)
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+Each action method call is recorded as one transaction. Multiple mutations inside one action are undone together. Use `$history.ignore()` for changes that should re-render but should not be recorded.
+
 ## Options
 
 The second argument to `model()` accepts optional configuration:
@@ -161,6 +193,7 @@ model(initial, {
   derive?: (state) => ({ key: () => value }),
   rules?: { field: (value) => true | 'error message' },
   onObserve?: (state) => void | (() => void),
+  history?: boolean | { limit?: number },
 })
 ```
 

--- a/apps/docs/content/docs/api/model.mdx
+++ b/apps/docs/content/docs/api/model.mdx
@@ -171,6 +171,8 @@ const todo = model(
 )
 ```
 
+`history: true` uses a default limit of 100 undo entries. Pass `history: { limit }` to override the stack size.
+
 No new hook is needed. Access `$history` through the existing hook from [`create()`](/docs/api/create).
 
 ```tsx

--- a/apps/docs/public/llm/history.txt
+++ b/apps/docs/public/llm/history.txt
@@ -1,0 +1,78 @@
+# comwit — History Reference
+
+History adds undo and redo to a model. It is disabled by default.
+
+## Enable
+
+```ts
+import { model } from 'comwit'
+
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: { limit: 100 },
+  }
+)
+```
+
+Use `history: true` for no limit.
+
+## Use
+
+No new hook is needed. Use the existing hook created by `create()`.
+
+```tsx
+const history = useTodo((s) => s.$history)
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+## Recording Model
+
+Each action method call is recorded as one transaction.
+
+```ts
+const todoActions = action(({ state }) => ({
+  add(title: string) {
+    const s = state(todo)
+    s.items.push({ id: crypto.randomUUID(), title, done: false })
+    s.selectedId = s.items.at(-1)!.id
+  },
+}))
+```
+
+Calling `s.$history.undo()` reverts both mutations together.
+
+## API
+
+```ts
+type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+```
+
+Use `ignore()` for changes that should re-render but should not enter the undo stack.
+
+```ts
+s.$history.ignore(() => {
+  s.draft = value
+})
+```
+
+`ignore()` is not the same as `silent()`. `silent()` suppresses notifications; `ignore()` only skips history recording.

--- a/apps/docs/public/llm/history.txt
+++ b/apps/docs/public/llm/history.txt
@@ -18,7 +18,7 @@ export const todo = model(
 )
 ```
 
-Use `history: true` for no limit.
+Use `history: true` for the default limit of 100 undo entries. Use `history: { limit }` to override the stack size.
 
 ## Use
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -18,9 +18,9 @@ Add `experimentalDecorators` to your `tsconfig.json`. Without this, Next.js prod
 // tsconfig.json
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
     // ... other options
-  }
+  },
 }
 ```
 
@@ -170,6 +170,20 @@ export const post = model<PostState>({
 })
 ```
 
+History is off by default. Enable it per model when user-facing state should support undo and redo:
+
+```ts
+export const todo = model(
+  {
+    items: [] as Todo[],
+    selectedId: null as string | null,
+  },
+  {
+    history: { limit: 100 },
+  }
+)
+```
+
 #### Derived State & Validation
 
 `model()` accepts an optional second argument with `derive` and `rules`:
@@ -190,8 +204,8 @@ export const cart = model<CartState, CartDerived>(
     }),
     // rules: per-field validation — accessed via state.$validation
     rules: {
-      coupon: (v) => (v.length <= 20) || 'Coupon too long',
-      items: (v) => (v.length > 0) || 'Cart is empty',
+      coupon: (v) => v.length <= 20 || 'Coupon too long',
+      items: (v) => v.length > 0 || 'Cart is empty',
     },
   }
 )
@@ -199,6 +213,21 @@ export const cart = model<CartState, CartDerived>(
 
 - Derived fields are readonly and throw if assigned.
 - Validation is accessed via `state.$validation`: `{ errors: { [field]: string | null }, isValid: boolean }`.
+
+#### History
+
+No new hook is needed. Use the existing domain hook and read `$history`:
+
+```tsx
+const { history } = useTodo((s) => ({ history: s.$history }))
+
+history.undo()
+history.redo()
+history.canUndo
+history.canRedo
+```
+
+Each action method call is one history transaction. Multiple mutations inside the method are undone together. Use `s.$history.ignore(() => { ... })` for changes that should re-render but should not be recorded. This is separate from `silent()`, which suppresses notifications.
 
 ### actions/\*.ts
 
@@ -321,6 +350,8 @@ const settings = model({
 
 For full API details, see the [Persist Reference](/llm/persist.txt).
 
+For full undo/redo details, see the [History Reference](/llm/history.txt).
+
 ## Usage
 
 ```tsx
@@ -342,18 +373,18 @@ Selectors use deep equality — only re-renders when selected values change.
 
 All from `'comwit'`. Stack on class methods.
 
-| Decorator                              | Purpose                                                           |
-| -------------------------------------- | ----------------------------------------------------------------- |
-| `@OnError(fn)`                         | Error handler. Re-throw to propagate.                             |
-| `@OnSuccess(fn)`                       | Success callback.                                                 |
-| `@Debounce(ms)`                        | Debounce.                                                         |
-| `@Throttle(ms)`                        | Throttle.                                                         |
-| `@Authorized({ when, onDeny })`        | Auth guard. `when: () => boolean \| Promise<boolean>`             |
-| `@Transaction()`                       | Transactional execution (experimental, currently no-op).          |
-| `@Retry(count, options?)`              | Retry on failure with fixed or exponential backoff.               |
-| `@Queue(strategy?)`                    | Concurrency control: `'drop'`, `'queue'`, or `'replace'`.        |
-| `@Log(level?)`                         | Console logging of calls, results, and errors.                    |
-| `@Validate(validators)`               | Argument validation before execution. Throws `ValidationError`.   |
+| Decorator                       | Purpose                                                         |
+| ------------------------------- | --------------------------------------------------------------- |
+| `@OnError(fn)`                  | Error handler. Re-throw to propagate.                           |
+| `@OnSuccess(fn)`                | Success callback.                                               |
+| `@Debounce(ms)`                 | Debounce.                                                       |
+| `@Throttle(ms)`                 | Throttle.                                                       |
+| `@Authorized({ when, onDeny })` | Auth guard. `when: () => boolean \| Promise<boolean>`           |
+| `@Transaction()`                | Transactional execution (experimental, currently no-op).        |
+| `@Retry(count, options?)`       | Retry on failure with fixed or exponential backoff.             |
+| `@Queue(strategy?)`             | Concurrency control: `'drop'`, `'queue'`, or `'replace'`.       |
+| `@Log(level?)`                  | Console logging of calls, results, and errors.                  |
+| `@Validate(validators)`         | Argument validation before execution. Throws `ValidationError`. |
 
 `intercept(hooks | factory)` — create custom decorators with lifecycle hooks. Supports immediate mode (hooks object) and lazy mode (factory with `state`/`context` access).
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -184,6 +184,8 @@ export const todo = model(
 )
 ```
 
+`history: true` uses a default limit of 100 undo entries. Pass `history: { limit }` to override the stack size.
+
 #### Derived State & Validation
 
 `model()` accepts an optional second argument with `derive` and `rules`:

--- a/packages/comwit/src/core/action.ts
+++ b/packages/comwit/src/core/action.ts
@@ -7,6 +7,7 @@ import {
 } from '../interceptors/utils'
 import { useStoreRegistry } from './provider'
 import type { BoundResourceState } from './query/types'
+import { runHistoryTransaction } from './history'
 
 export type State = <T extends object>(model: Model<T>) => BoundResourceState<T>
 
@@ -96,7 +97,7 @@ function normalizeActions<A, C extends object = Record<string, never>>(
       continue
     }
 
-    out[key] = bindValue(value as AnyFunction, instance, ctx)
+    out[key] = bindValue(value as AnyFunction, instance, ctx, key)
   }
 
   for (
@@ -110,7 +111,7 @@ function normalizeActions<A, C extends object = Record<string, never>>(
       const fn = descriptor?.value
 
       if (typeof fn !== 'function') continue
-      out[key] = bindValue(fn as AnyFunction, instance, ctx)
+      out[key] = bindValue(fn as AnyFunction, instance, ctx, key)
     }
   }
 
@@ -120,19 +121,24 @@ function normalizeActions<A, C extends object = Record<string, never>>(
 function bindValue<C extends object>(
   fn: AnyFunction,
   instance: object,
-  ctx: ActionContext<C>
+  ctx: ActionContext<C>,
+  name: string
 ): AnyFunction {
-  return resolveLazyInterceptors(fn, ctx).bind(instance)
+  const transactional = function (this: unknown, ...args: unknown[]) {
+    return runHistoryTransaction(name, () => fn.apply(this, args))
+  }
+  return resolveLazyInterceptors(fn, ctx, transactional).bind(instance)
 }
 
 function resolveLazyInterceptors<C extends object = Record<string, never>>(
   fn: AnyFunction,
-  ctx: ActionContext<C>
+  ctx: ActionContext<C>,
+  initial: AnyFunction = fn
 ): AnyFunction {
   const factories = getLazyInterceptorFactories(fn) as Array<LazyInterceptorFactory<C>>
-  if (!factories.length) return fn
+  if (!factories.length) return initial
 
-  let next = fn
+  let next = initial
   for (const factory of factories) {
     const decorator = factory({ state: ctx.state, context: ctx.context })
     if (typeof decorator !== 'function') continue

--- a/packages/comwit/src/core/history.ts
+++ b/packages/comwit/src/core/history.ts
@@ -1,0 +1,394 @@
+import { snapshot, subscribeOps, type Path, type ProxyOp } from './proxy'
+
+export type HistoryOptions = {
+  limit?: number
+}
+
+export type HistoryConfig = boolean | HistoryOptions
+
+export type HistoryApi = {
+  canUndo: boolean
+  canRedo: boolean
+  isPaused: boolean
+  undo(steps?: number): void
+  redo(steps?: number): void
+  clear(): void
+  pause(): void
+  resume(): void
+  ignore<T>(fn: () => T): T
+  transaction<T>(fn: () => T): T
+  transaction<T>(label: string, fn: () => T): T
+}
+
+type HistoryPatch =
+  | {
+      op: 'set'
+      path: Path
+      value: unknown
+      arrayLength?: number
+    }
+  | {
+      op: 'delete'
+      path: Path
+      arrayLength?: number
+    }
+
+type HistoryEntry = {
+  label?: string
+  patches: HistoryPatch[]
+  inversePatches: HistoryPatch[]
+}
+
+type HistoryTransaction = {
+  label?: string
+  entries: Map<HistoryController, ProxyOp[]>
+}
+
+let ignoreDepth = 0
+const transactions: HistoryTransaction[] = []
+
+export function normalizeHistoryOptions(config: HistoryConfig | undefined): HistoryOptions | null {
+  if (!config) return null
+  if (config === true) return {}
+  return config
+}
+
+export function runHistoryTransaction<T>(label: string | undefined, fn: () => T): T {
+  const tx: HistoryTransaction = { label, entries: new Map() }
+  transactions.push(tx)
+
+  let result: T
+  try {
+    result = fn()
+  } catch (error) {
+    transactions.pop()
+    throw error
+  }
+
+  if (isThenable(result)) {
+    return result.then(
+      (value) => {
+        finishTransaction(tx, true)
+        return value
+      },
+      (error) => {
+        finishTransaction(tx, false)
+        throw error
+      }
+    ) as T
+  }
+
+  finishTransaction(tx, true)
+  return result
+}
+
+export function runHistoryIgnored<T>(fn: () => T): T {
+  ignoreDepth++
+  try {
+    return fn()
+  } finally {
+    ignoreDepth--
+  }
+}
+
+export function recordHistoryOp(controller: HistoryController, op: ProxyOp | undefined): void {
+  if (!op || ignoreDepth > 0 || controller.isApplying || controller.isPaused) return
+  const tx = transactions[transactions.length - 1]
+  if (!tx) return
+
+  const ops = tx.entries.get(controller)
+  if (ops) {
+    ops.push(cloneProxyOp(op))
+  } else {
+    tx.entries.set(controller, [cloneProxyOp(op)])
+  }
+}
+
+function finishTransaction(tx: HistoryTransaction, shouldCommit: boolean): void {
+  const top = transactions.pop()
+  if (top !== tx) {
+    throw new Error('[comwit] history transaction stack is corrupted')
+  }
+
+  if (!shouldCommit) return
+
+  const parent = transactions[transactions.length - 1]
+  if (parent) {
+    for (const [controller, ops] of tx.entries) {
+      const existing = parent.entries.get(controller)
+      if (existing) existing.push(...ops)
+      else parent.entries.set(controller, ops)
+    }
+    return
+  }
+
+  for (const [controller, ops] of tx.entries) {
+    controller.commit(ops, tx.label)
+  }
+}
+
+function isThenable<T>(value: unknown): value is PromiseLike<T> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as PromiseLike<T>).then === 'function'
+  )
+}
+
+export class HistoryController {
+  readonly apiMethods: Omit<HistoryApi, 'canUndo' | 'canRedo' | 'isPaused'>
+
+  private past: HistoryEntry[] = []
+  private future: HistoryEntry[] = []
+  private listeners = new Set<() => void>()
+  private cleanup: (() => void) | null = null
+  private paused = false
+  private applying = false
+  private readonly limit: number | null
+
+  constructor(
+    private readonly proxy: object,
+    options: HistoryOptions = {}
+  ) {
+    this.limit = typeof options.limit === 'number' && options.limit >= 0 ? options.limit : null
+    this.apiMethods = {
+      undo: (steps) => this.undo(steps),
+      redo: (steps) => this.redo(steps),
+      clear: () => this.clear(),
+      pause: () => this.pause(),
+      resume: () => this.resume(),
+      ignore: (fn) => runHistoryIgnored(fn),
+      transaction: ((labelOrFn: string | (() => unknown), maybeFn?: () => unknown) => {
+        const label = typeof labelOrFn === 'string' ? labelOrFn : undefined
+        const fn = typeof labelOrFn === 'string' ? maybeFn! : labelOrFn
+        return runHistoryTransaction(label, fn)
+      }) as HistoryApi['transaction'],
+    }
+
+    this.cleanup = subscribeOps(proxy, (op) => recordHistoryOp(this, op))
+  }
+
+  get isApplying(): boolean {
+    return this.applying
+  }
+
+  get isPaused(): boolean {
+    return this.paused
+  }
+
+  get canUndo(): boolean {
+    return this.past.length > 0
+  }
+
+  get canRedo(): boolean {
+    return this.future.length > 0
+  }
+
+  getApi(): HistoryApi {
+    return {
+      canUndo: this.canUndo,
+      canRedo: this.canRedo,
+      isPaused: this.isPaused,
+      ...this.apiMethods,
+    }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  destroy(): void {
+    this.cleanup?.()
+    this.cleanup = null
+    this.listeners.clear()
+  }
+
+  commit(ops: ProxyOp[], label?: string): void {
+    const entry = createHistoryEntry(ops, label)
+    if (!entry) return
+
+    this.past.push(entry)
+    if (this.limit !== null && this.past.length > this.limit) {
+      this.past.splice(0, this.past.length - this.limit)
+    }
+    this.future = []
+    this.notify()
+  }
+
+  undo(steps = 1): void {
+    const count = normalizeStepCount(steps)
+    for (let i = 0; i < count; i++) {
+      const entry = this.past.pop()
+      if (!entry) break
+      this.apply(entry.inversePatches)
+      this.future.push(entry)
+    }
+    this.notify()
+  }
+
+  redo(steps = 1): void {
+    const count = normalizeStepCount(steps)
+    for (let i = 0; i < count; i++) {
+      const entry = this.future.pop()
+      if (!entry) break
+      this.apply(entry.patches)
+      this.past.push(entry)
+    }
+    this.notify()
+  }
+
+  clear(): void {
+    if (!this.past.length && !this.future.length) return
+    this.past = []
+    this.future = []
+    this.notify()
+  }
+
+  pause(): void {
+    if (this.paused) return
+    this.paused = true
+    this.notify()
+  }
+
+  resume(): void {
+    if (!this.paused) return
+    this.paused = false
+    this.notify()
+  }
+
+  private apply(patches: HistoryPatch[]): void {
+    this.applying = true
+    try {
+      for (const patch of patches) {
+        applyPatch(this.proxy, patch)
+      }
+    } finally {
+      this.applying = false
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener())
+  }
+}
+
+export function createHistoryController(proxy: object, options: HistoryOptions): HistoryController {
+  return new HistoryController(proxy, options)
+}
+
+function createHistoryEntry(ops: ProxyOp[], label?: string): HistoryEntry | null {
+  const patches: HistoryPatch[] = []
+  const inversePatches: HistoryPatch[] = []
+
+  for (const op of ops) {
+    const patch = toPatch(op)
+    if (!patch) continue
+    patches.push(patch.patch)
+    inversePatches.unshift(patch.inversePatch)
+  }
+
+  if (!patches.length) return null
+  return { label, patches, inversePatches }
+}
+
+function toPatch(op: ProxyOp): { patch: HistoryPatch; inversePatch: HistoryPatch } | null {
+  if (op[0] === 'set') {
+    const [, path, value, prevValue, hadPrevValue, meta] = op
+    const patch: HistoryPatch = {
+      op: 'set',
+      path: [...path],
+      value: cloneHistoryValue(value),
+      arrayLength: meta?.nextLength,
+    }
+    const inversePatch: HistoryPatch = hadPrevValue
+      ? {
+          op: 'set',
+          path: [...path],
+          value: cloneHistoryValue(prevValue),
+          arrayLength: meta?.prevLength,
+        }
+      : {
+          op: 'delete',
+          path: [...path],
+          arrayLength: meta?.prevLength,
+        }
+    return { patch, inversePatch }
+  }
+
+  const [, path, prevValue, hadPrevValue] = op
+  if (!hadPrevValue) return null
+  return {
+    patch: { op: 'delete', path: [...path] },
+    inversePatch: { op: 'set', path: [...path], value: cloneHistoryValue(prevValue) },
+  }
+}
+
+function applyPatch(root: object, patch: HistoryPatch): void {
+  const parent = getPatchParent(root, patch.path)
+  if (!parent) return
+
+  const key = patch.path[patch.path.length - 1]
+  if (patch.op === 'set') {
+    Reflect.set(parent, key, cloneHistoryValue(patch.value))
+  } else {
+    Reflect.deleteProperty(parent, key)
+  }
+
+  if (typeof patch.arrayLength === 'number' && Array.isArray(parent)) {
+    parent.length = patch.arrayLength
+  }
+}
+
+function getPatchParent(root: object, path: Path): any {
+  if (!path.length) return null
+
+  let current: any = root
+  for (let i = 0; i < path.length - 1; i++) {
+    current = current?.[path[i]]
+    if (current === null || current === undefined) return null
+  }
+  return current
+}
+
+function cloneProxyOp(op: ProxyOp): ProxyOp {
+  if (op[0] === 'set') {
+    const [, path, value, prevValue, hadPrevValue, meta] = op
+    return [
+      'set',
+      [...path],
+      cloneHistoryValue(value),
+      cloneHistoryValue(prevValue),
+      hadPrevValue,
+      meta ? { ...meta } : undefined,
+    ]
+  }
+
+  const [, path, prevValue, hadPrevValue, meta] = op
+  return [
+    'delete',
+    [...path],
+    cloneHistoryValue(prevValue),
+    hadPrevValue,
+    meta ? { ...meta } : undefined,
+  ]
+}
+
+function cloneHistoryValue(value: unknown): unknown {
+  if (value && typeof value === 'object') {
+    try {
+      return structuredClone(snapshot(value as object))
+    } catch {}
+    try {
+      return structuredClone(value)
+    } catch {
+      return value
+    }
+  }
+  return value
+}
+
+function normalizeStepCount(steps: number): number {
+  if (!Number.isFinite(steps)) return 1
+  return Math.max(0, Math.floor(steps))
+}

--- a/packages/comwit/src/core/history.ts
+++ b/packages/comwit/src/core/history.ts
@@ -6,6 +6,8 @@ export type HistoryOptions = {
 
 export type HistoryConfig = boolean | HistoryOptions
 
+export const DEFAULT_HISTORY_LIMIT = 100
+
 export type HistoryApi = {
   canUndo: boolean
   canRedo: boolean
@@ -49,8 +51,8 @@ const transactions: HistoryTransaction[] = []
 
 export function normalizeHistoryOptions(config: HistoryConfig | undefined): HistoryOptions | null {
   if (!config) return null
-  if (config === true) return {}
-  return config
+  if (config === true) return { limit: DEFAULT_HISTORY_LIMIT }
+  return { limit: config.limit ?? DEFAULT_HISTORY_LIMIT }
 }
 
 export function runHistoryTransaction<T>(label: string | undefined, fn: () => T): T {
@@ -144,13 +146,16 @@ export class HistoryController {
   private cleanup: (() => void) | null = null
   private paused = false
   private applying = false
-  private readonly limit: number | null
+  private readonly limit: number
 
   constructor(
     private readonly proxy: object,
     options: HistoryOptions = {}
   ) {
-    this.limit = typeof options.limit === 'number' && options.limit >= 0 ? options.limit : null
+    this.limit =
+      typeof options.limit === 'number' && options.limit >= 0
+        ? options.limit
+        : DEFAULT_HISTORY_LIMIT
     this.apiMethods = {
       undo: (steps) => this.undo(steps),
       redo: (steps) => this.redo(steps),
@@ -209,7 +214,7 @@ export class HistoryController {
     if (!entry) return
 
     this.past.push(entry)
-    if (this.limit !== null && this.past.length > this.limit) {
+    if (this.past.length > this.limit) {
       this.past.splice(0, this.past.length - this.limit)
     }
     this.future = []

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -21,6 +21,7 @@ export type { FieldPlugin, PluginBag } from './plugin'
 import { persistPlugin } from './persist'
 import { persist, type PersistAdapter, type PersistOptions, type PersistDefaults } from './persist'
 import { initDevTools } from './devtools'
+import type { HistoryApi, HistoryOptions, HistoryConfig } from './history'
 
 import { computedPlugin } from './computed'
 import { computed } from './computed'
@@ -82,4 +83,7 @@ export type {
   PersistOptions,
   PersistDefaults,
   Snapshotable,
+  HistoryApi,
+  HistoryOptions,
+  HistoryConfig,
 }

--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -5,17 +5,27 @@ import { useStoreRegistry } from './provider'
 import { isEqual } from '../utils'
 import { isSilent } from './silent'
 import { COMPUTED_PLUGIN_NAME, createComputedProxy, getComputedSnapshot } from './computed'
+import {
+  createHistoryController,
+  normalizeHistoryOptions,
+  type HistoryApi,
+  type HistoryConfig,
+  type HistoryController,
+  type HistoryOptions,
+} from './history'
 
 export type StoreEntry<T extends object = any> = {
   proxy: T
   getSnapshot(): T
   subscribe(listener: () => void): () => void
+  history?: HistoryController
 }
 
 export type ModelOptions<T extends object, D extends object = {}> = {
   derive?: (state: T) => { [K in keyof D]: () => D[K] }
   rules?: { [K in keyof T]?: (value: T[K]) => true | string }
   onObserve?: (state: T) => void | (() => void)
+  history?: HistoryConfig
 }
 
 export type ValidationState<T> = {
@@ -24,6 +34,10 @@ export type ValidationState<T> = {
 }
 
 export function model<T extends object>(initial: T): Model<T>
+export function model<T extends object, D extends object>(
+  initial: T,
+  options: ModelOptions<T, D> & { history: true | HistoryOptions }
+): Model<T & Readonly<D> & { $validation: ValidationState<T>; $history: HistoryApi }>
 export function model<T extends object, D extends object>(
   initial: T,
   options: ModelOptions<T, D>
@@ -48,6 +62,8 @@ export function model<T extends object, D extends object = {}>(
     onObserve: options?.onObserve as Model<T & Readonly<D>>['onObserve'],
     instance(): StoreEntry<T & Readonly<D>> {
       const p = createProxy(cloneState())
+      const historyOptions = normalizeHistoryOptions(options?.history)
+      const history = historyOptions ? createHistoryController(p, historyOptions) : null
 
       const deriveFactory = options?.derive
       const rules = options?.rules
@@ -61,7 +77,8 @@ export function model<T extends object, D extends object = {}>(
 
       const computedBag = pluginBags.get(COMPUTED_PLUGIN_NAME)
       const hasComputed = computedBag != null && computedBag.size > 0
-      const hasExtensions = derivedGetters != null || rules != null || hasComputed
+      const hasHistory = history != null
+      const hasExtensions = derivedGetters != null || rules != null || hasComputed || hasHistory
 
       let computedProxyRef: object | null = null
       let publicProxy: unknown = p
@@ -73,6 +90,9 @@ export function model<T extends object, D extends object = {}>(
         const base = publicProxy as object
         publicProxy = new Proxy(base, {
           get(target, prop, receiver) {
+            if (prop === '$history' && history) {
+              return history.getApi()
+            }
             if (typeof prop === 'string' && derivedKeys?.has(prop)) {
               return derivedGetters![prop]()
             }
@@ -88,6 +108,25 @@ export function model<T extends object, D extends object = {}>(
             if (prop === '$validation') {
               throw new Error('Cannot set $validation')
             }
+            if (prop === '$history') {
+              throw new Error('Cannot set $history')
+            }
+            return Reflect.set(target, prop, value, receiver)
+          },
+        })
+      } else if (history) {
+        const base = publicProxy as object
+        publicProxy = new Proxy(base, {
+          get(target, prop, receiver) {
+            if (prop === '$history') {
+              return history.getApi()
+            }
+            return Reflect.get(target, prop, receiver)
+          },
+          set(target, prop, value, receiver) {
+            if (prop === '$history') {
+              throw new Error('Cannot set $history')
+            }
             return Reflect.set(target, prop, value, receiver)
           },
         })
@@ -95,6 +134,7 @@ export function model<T extends object, D extends object = {}>(
 
       return {
         proxy: publicProxy as T & Readonly<D>,
+        history: history ?? undefined,
         getSnapshot() {
           if (!hasExtensions) return snapshot(p) as T & Readonly<D>
 
@@ -115,12 +155,21 @@ export function model<T extends object, D extends object = {}>(
             result.$validation = computeValidation(p as Record<string, unknown>, rules)
           }
 
+          if (history) {
+            result.$history = history.getApi()
+          }
+
           return Object.freeze(result) as T & Readonly<D>
         },
         subscribe(listener) {
-          return subscribe(p, () => {
+          const unsubProxy = subscribe(p, () => {
             if (!isSilent()) listener()
           })
+          const unsubHistory = history?.subscribe(listener)
+          return () => {
+            unsubProxy()
+            unsubHistory?.()
+          }
         },
       }
     },

--- a/packages/comwit/src/core/proxy.ts
+++ b/packages/comwit/src/core/proxy.ts
@@ -11,11 +11,22 @@ const $ref = Symbol('ref') // marks objects excluded from proxying
 const $snap = Symbol('snap') // snapshot cache on target
 const $proxy = Symbol('proxy') // cached proxy on base object
 
-type Path = (string | symbol)[]
-type Op =
-  | [op: 'set', path: Path, value: unknown, prevValue: unknown]
-  | [op: 'delete', path: Path, prevValue: unknown]
-type Listener = (op: Op | undefined, nextVersion: number) => void
+export type Path = (string | symbol)[]
+export type ProxyOpMeta = {
+  prevLength?: number
+  nextLength?: number
+}
+export type ProxyOp =
+  | [
+      op: 'set',
+      path: Path,
+      value: unknown,
+      prevValue: unknown,
+      hadPrevValue: boolean,
+      meta?: ProxyOpMeta,
+    ]
+  | [op: 'delete', path: Path, prevValue: unknown, hadPrevValue: boolean, meta?: ProxyOpMeta]
+type Listener = (op: ProxyOp | undefined, nextVersion: number) => void
 type RemoveListener = () => void
 type AddListener = (listener: Listener) => RemoveListener
 type ProxyState = readonly [
@@ -96,7 +107,7 @@ function createHandler<T extends object>(
   isInitializing: () => boolean,
   addPropListener: (prop: string | symbol, propValue: unknown) => void,
   removePropListener: (prop: string | symbol) => void,
-  notifyUpdate: (op: Op | undefined) => void
+  notifyUpdate: (op: ProxyOp | undefined) => void
 ): ProxyHandler<T> {
   return {
     get(target: T, prop: string | symbol, receiver: object) {
@@ -110,17 +121,19 @@ function createHandler<T extends object>(
       return Reflect.get(target, prop, receiver)
     },
     deleteProperty(target: T, prop: string | symbol) {
+      const hadPrevValue = Reflect.has(target, prop)
       const prevValue = Reflect.get(target, prop)
       removePropListener(prop)
       const deleted = Reflect.deleteProperty(target, prop)
       if (deleted) {
-        notifyUpdate(['delete', [prop], prevValue])
+        notifyUpdate(['delete', [prop], prevValue, hadPrevValue])
       }
       return deleted
     },
     set(target: T, prop: string | symbol, value: any, receiver: object) {
       const hasPrevValue = !isInitializing() && Reflect.has(target, prop)
       const prevValue = Reflect.get(target, prop, receiver)
+      const prevLength = Array.isArray(target) ? target.length : undefined
       const cachedProxy = isObject(value) && getCachedProxy(value)
       if (
         hasPrevValue &&
@@ -132,7 +145,12 @@ function createHandler<T extends object>(
       const nextValue = !getProxyState(value) && canProxy(value) ? proxyInner(value) : value
       addPropListener(prop, nextValue)
       Reflect.set(target, prop, nextValue, receiver)
-      notifyUpdate(['set', [prop], value, prevValue])
+      const nextLength = Array.isArray(target) ? target.length : undefined
+      const meta =
+        prevLength !== undefined && nextLength !== undefined && prevLength !== nextLength
+          ? { prevLength, nextLength }
+          : undefined
+      notifyUpdate(['set', [prop], value, prevValue, hasPrevValue, meta])
       return true
     },
   }
@@ -156,7 +174,7 @@ function proxyInner<T extends object>(baseObject: T): T {
   }
   let version = globalVersion
   const listeners = new Set<Listener>()
-  const notifyUpdate = (op: Op | undefined, nextVersion = ++globalVersion) => {
+  const notifyUpdate = (op: ProxyOp | undefined, nextVersion = ++globalVersion) => {
     if (version !== nextVersion) {
       checkVersion = version = nextVersion
       listeners.forEach((listener) => listener(op, nextVersion))
@@ -178,7 +196,7 @@ function proxyInner<T extends object>(baseObject: T): T {
   const createPropListener =
     (prop: string | symbol): Listener =>
     (op, nextVersion) => {
-      let newOp: Op | undefined
+      let newOp: ProxyOp | undefined
       if (op) {
         newOp = [...op]
         newOp[1] = [prop, ...(newOp[1] as Path)]
@@ -300,6 +318,29 @@ export function subscribe<T extends object>(state: T, callback: () => void): () 
   const listener: Listener = () => {
     if (isListenerActive) {
       callback()
+    }
+  }
+  const removeListener = addListener(listener)
+  isListenerActive = true
+  return () => {
+    isListenerActive = false
+    removeListener()
+  }
+}
+
+export function subscribeOps<T extends object>(
+  state: T,
+  callback: (op: ProxyOp | undefined, nextVersion: number) => void
+): () => void {
+  const proxyState = getProxyState(state)
+  if (!proxyState) {
+    throw new Error('Please use proxy object')
+  }
+  const addListener = proxyState[2]
+  let isListenerActive = false
+  const listener: Listener = (op, nextVersion) => {
+    if (isListenerActive) {
+      callback(op, nextVersion)
     }
   }
   const removeListener = addListener(listener)

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -223,9 +223,11 @@ export type BoundResourceState<T> =
               ? BoundSingleResourceState<TData, unknown>
               : T extends (infer U)[]
                 ? BoundResourceState<U>[]
-                : T extends object
-                  ? { [K in keyof T]: BoundResourceState<T[K]> }
-                  : T
+                : T extends (...args: any[]) => any
+                  ? T
+                  : T extends object
+                    ? { [K in keyof T]: BoundResourceState<T[K]> }
+                    : T
 
 export type DependentQueryOptions<TData> = {
   enabled?: (state: any) => boolean

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -25,5 +25,8 @@ export type {
   PersistOptions,
   PersistDefaults,
   Snapshotable,
+  HistoryApi,
+  HistoryOptions,
+  HistoryConfig,
 } from './core'
 export * from './interceptors'

--- a/packages/comwit/tests/history.test.tsx
+++ b/packages/comwit/tests/history.test.tsx
@@ -143,6 +143,82 @@ describe('history', () => {
     expect(result.current.state.$history.canRedo).toBe(false)
   })
 
+  test('uses a default limit of 100 undo entries', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      increment() {
+        state(counter).count += 1
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ increment: () => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      for (let i = 0; i < 101; i++) {
+        result.current.actions.increment()
+      }
+    })
+
+    expect(result.current.state.count).toBe(101)
+
+    await act(async () => {
+      result.current.state.$history.undo(100)
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.$history.canUndo).toBe(false)
+  })
+
+  test('buckets one action transaction by each changed model', async () => {
+    const profile = model({ name: 'Ada' }, { history: true })
+    const settings = model({ theme: 'light' }, { history: true })
+    const actions = action(({ state }) => ({
+      updateBoth() {
+        state(profile).name = 'Grace'
+        state(settings).theme = 'dark'
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        profile: useModel(profile),
+        settings: useModel(settings),
+        actions: useAction<{ updateBoth: () => void }>([actions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.updateBoth()
+    })
+
+    expect(result.current.profile.name).toBe('Grace')
+    expect(result.current.settings.theme).toBe('dark')
+    expect(result.current.profile.$history.canUndo).toBe(true)
+    expect(result.current.settings.$history.canUndo).toBe(true)
+
+    await act(async () => {
+      result.current.profile.$history.undo()
+    })
+
+    expect(result.current.profile.name).toBe('Ada')
+    expect(result.current.settings.theme).toBe('dark')
+
+    await act(async () => {
+      result.current.settings.$history.undo()
+    })
+
+    expect(result.current.settings.theme).toBe('light')
+  })
+
   test('supports ignore without suppressing rendering', async () => {
     const counter = model({ count: 0 }, { history: true })
     const counterActions = action(({ state }) => ({

--- a/packages/comwit/tests/history.test.tsx
+++ b/packages/comwit/tests/history.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from 'vitest'
+import React from 'react'
+import { act, renderHook } from '@testing-library/react'
+import { action, ComwitProvider, create, model, useAction, useModel } from '../src'
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <ComwitProvider>{children}</ComwitProvider>
+  }
+}
+
+describe('history', () => {
+  test('is disabled by default', () => {
+    const counter = model({ count: 0 })
+    const store = counter.instance()
+
+    expect('$history' in store.getSnapshot()).toBe(false)
+  })
+
+  test('exposes $history when enabled', () => {
+    const counter = model({ count: 0 }, { history: true })
+    const store = counter.instance()
+    const snap = store.getSnapshot()
+
+    expect(snap.$history.canUndo).toBe(false)
+    expect(snap.$history.canRedo).toBe(false)
+    expect(typeof snap.$history.undo).toBe('function')
+    expect(typeof snap.$history.redo).toBe('function')
+  })
+
+  test('records one action method as one undo step', async () => {
+    const counter = model({ count: 0, label: 'idle' }, { history: true })
+    const counterActions = action(({ state }) => ({
+      update() {
+        const s = state(counter)
+        s.count += 1
+        s.label = 'updated'
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ update: () => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.update()
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.label).toBe('updated')
+    expect(result.current.state.$history.canUndo).toBe(true)
+    expect(result.current.state.$history.canRedo).toBe(false)
+
+    await act(async () => {
+      result.current.state.$history.undo()
+    })
+
+    expect(result.current.state.count).toBe(0)
+    expect(result.current.state.label).toBe('idle')
+    expect(result.current.state.$history.canUndo).toBe(false)
+    expect(result.current.state.$history.canRedo).toBe(true)
+
+    await act(async () => {
+      result.current.state.$history.redo()
+    })
+
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.label).toBe('updated')
+    expect(result.current.state.$history.canUndo).toBe(true)
+    expect(result.current.state.$history.canRedo).toBe(false)
+  })
+
+  test('restores array pushes without leaving sparse items', async () => {
+    const todo = model({ items: [] as string[] }, { history: true })
+    const todoActions = action(({ state }) => ({
+      add(item: string) {
+        state(todo).items.push(item)
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(todo),
+        actions: useAction<{ add: (item: string) => void }>([todoActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.add('buy milk')
+    })
+
+    expect(result.current.state.items).toEqual(['buy milk'])
+
+    await act(async () => {
+      result.current.state.$history.undo()
+    })
+
+    expect(result.current.state.items).toEqual([])
+    expect(result.current.state.items.length).toBe(0)
+
+    await act(async () => {
+      result.current.state.$history.redo()
+    })
+
+    expect(result.current.state.items).toEqual(['buy milk'])
+  })
+
+  test('clears redo stack when a new action is committed after undo', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      add(value: number) {
+        state(counter).count += value
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ add: (value: number) => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => result.current.actions.add(1))
+    await act(async () => result.current.actions.add(1))
+    expect(result.current.state.count).toBe(2)
+
+    await act(async () => result.current.state.$history.undo())
+    expect(result.current.state.count).toBe(1)
+    expect(result.current.state.$history.canRedo).toBe(true)
+
+    await act(async () => result.current.actions.add(10))
+    expect(result.current.state.count).toBe(11)
+    expect(result.current.state.$history.canRedo).toBe(false)
+  })
+
+  test('supports ignore without suppressing rendering', async () => {
+    const counter = model({ count: 0 }, { history: true })
+    const counterActions = action(({ state }) => ({
+      setIgnored(value: number) {
+        const s = state(counter)
+        s.$history.ignore(() => {
+          s.count = value
+        })
+      },
+    }))
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () => ({
+        state: useModel(counter),
+        actions: useAction<{ setIgnored: (value: number) => void }>([counterActions]),
+      }),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.setIgnored(5)
+    })
+
+    expect(result.current.state.count).toBe(5)
+    expect(result.current.state.$history.canUndo).toBe(false)
+  })
+
+  test('works through create() without adding a new hook', async () => {
+    const todo = model({ items: [] as string[] }, { history: true })
+    const todoActions = action(({ state }) => ({
+      add(item: string) {
+        state(todo).items.push(item)
+      },
+    }))
+    const useTodo = create(todo, { actions: [todoActions] })
+
+    const wrapper = createWrapper()
+    const { result } = renderHook(
+      () =>
+        useTodo((s) => ({
+          items: s.items,
+          actions: s.actions,
+          history: s.$history,
+        })),
+      { wrapper }
+    )
+
+    await act(async () => {
+      result.current.actions.add('ship history')
+    })
+
+    expect(result.current.items).toEqual(['ship history'])
+    expect(result.current.history.canUndo).toBe(true)
+
+    await act(async () => {
+      result.current.history.undo()
+    })
+
+    expect(result.current.items).toEqual([])
+    expect(result.current.history.canRedo).toBe(true)
+  })
+})

--- a/packages/comwit/tests/snapshot-types.test.ts
+++ b/packages/comwit/tests/snapshot-types.test.ts
@@ -80,3 +80,17 @@ test('action state() — standalone snapshot() converts nested slices', () => {
     return {}
   })
 })
+
+test('history-enabled models expose $history methods', () => {
+  const m = model({ count: 0 }, { history: true })
+
+  action(({ state }) => {
+    const s = state(m)
+    expectTypeOf(s.$history.canUndo).toEqualTypeOf<boolean>()
+    expectTypeOf(s.$history.undo).toBeFunction()
+    expectTypeOf(s.$history.redo).toBeFunction()
+    s.$history.undo()
+    s.$history.redo()
+    return {}
+  })
+})


### PR DESCRIPTION
## Summary

Adds a built-in undo/redo history controller per model.

- New \`model(initial, { history: true | HistoryOptions })\` option creates a \`HistoryController\` for the model.
- Exposes a \`$history\` API on the model proxy (\`undo()\`, \`redo()\`, etc.) — guarded so it cannot be assigned.
- Action methods are wrapped via \`runHistoryTransaction(name, fn)\` so each invocation is a single, named history entry.
- Default history limit is **100** entries.

## Why this targets \`v2\`

Touches the public \`ModelOptions\` / proxy surface, so it lands on the v2 integration branch alongside the other breaking changes (observer-based \`gcTime\`, dropped \`cacheTime\` alias — see #74).

## Commits

- \`03e865e\` — feat: add model history undo redo
- \`0233a91\` — chore: ignore claude worktrees
- \`1dec16f\` — fix: default history limit to 100

## Test plan

- [ ] Verify undo/redo across nested proxy mutations
- [ ] Verify action-wrapped transactions group multiple mutations into one entry
- [ ] Verify \`$history\` is read-only on the proxy
- [ ] Confirm \`HistoryConfig\`/\`HistoryOptions\` types are exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)