### PR TITLE
fix(query): refetch() always returns a Promise

### DIFF
--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -648,7 +648,7 @@ export function createResourceAccessor(
 
   const refetch = () => {
     const active = getActiveEntry()
-    if (!active?.hasQueried) return
+    if (!active?.hasQueried) return Promise.resolve()
     return executeQuery(active.arg, undefined, true, 'replace', true)
   }
 

--- a/packages/comwit/tests/query.test.ts
+++ b/packages/comwit/tests/query.test.ts
@@ -362,6 +362,19 @@ describe('query', () => {
       expect(queryFn).not.toHaveBeenCalled()
     })
 
+    it('should always return a Promise — even when no entry has been queried', async () => {
+      const queryFn = vi.fn().mockResolvedValue(['data'])
+      const bound = createBound({
+        initialData: [] as string[],
+        queryFn,
+      })
+
+      // 타입 컨트랙트는 Promise<unknown> — 호출자가 .then/.catch 를 붙여도 안전해야 한다.
+      const result = bound.refetch()
+      expect(result).toBeInstanceOf(Promise)
+      await expect(result).resolves.toBeUndefined()
+    })
+
     it('should re-execute last query after successful query', async () => {
       const queryFn = vi.fn().mockResolvedValueOnce(['first']).mockResolvedValueOnce(['second'])
 


### PR DESCRIPTION
## Summary
- Bound query's \`refetch()\` returned \`undefined\` synchronously when no entry had been queried yet, while the public type declares \`refetch(): Promise<unknown>\`.
- Callers chaining \`.then()\` / \`.catch()\` on the result crashed with \`TypeError: Cannot read properties of undefined (reading 'catch')\`.
- Fix: return \`Promise.resolve()\` in the no-op branch so the type contract holds.

## Repro
\`\`\`ts
// page A mounts model with a query 'items'; page B never mounted it
items.refetch().catch(() => undefined) // 💥 TypeError before this fix
\`\`\`

The existing \"do nothing if no prior query\" test used \`await refetch()\`, which coerces \`undefined\` to a resolved promise — so it didn't surface the bug. Added a regression test that asserts the return value is a \`Promise\` and resolves.

## Test plan
- [x] \`yarn test\` — 333 tests pass
- [x] Added regression: refetch must return a Promise even with no active entry