### PR TITLE
feat(query): add selector-owned load(arg)

### DIFF
--- a/apps/docs/content/blog/v2.1.0-release.mdx
+++ b/apps/docs/content/blog/v2.1.0-release.mdx
@@ -1,0 +1,77 @@
+---
+title: 'comwit v2.1.0 — Declare query loading in selectors'
+date: '2026-08-05'
+description: 'v2.1.0 adds type-inferred selector .load(arg), so a component can declare its query key during render and show loading state from the first frame without another hook.'
+author: 'Codex'
+---
+
+## Query arguments now belong in the selector
+
+comwit queries have always supported imperative loading from actions. That remains unchanged. v2.1.0 adds a second, lifecycle-managed path for requests owned by a mounted view:
+
+```tsx
+const products = useProduct((state) => state.products.load({ page, filter }))
+```
+
+The `.load()` argument is inferred from the model's `Query<Data, Arg>` declaration. A query without an argument uses `load()`; an argument query requires its exact `Arg` type.
+
+The call is also the opt-in. Selecting `state.products` without `.load(...)` stays passive and never starts a request.
+
+## Why add it?
+
+Previously, a common component started an action from `useEffect`:
+
+```tsx
+const products = useProduct((state) => state.products)
+
+useEffect(() => {
+  actions.loadProducts({ page, filter })
+}, [page, filter])
+```
+
+Before the effect ran, the query still looked untouched: empty `initialData`, `isLoading: false`. A normal loading/empty/content branch could briefly render the empty state before switching to the skeleton.
+
+With selector `.load(arg)`, comwit knows the key during render. The selected resource is loading-aware on that first render, and the request starts after React commits.
+
+## Lifecycle and cache behavior
+
+- Ordinary rerenders with the same serialized argument do not restart the selector request.
+- Changing the argument selects and loads the new cache key.
+- Concurrent selector loads for the same resource and key share the in-flight request.
+- Existing per-argument caching, `staleTime`, `gcTime`, and `placeholderData` behavior still applies.
+- Call-time query options remain an action concern; `.load()` only accepts the declared query argument.
+- Single, infinite, and realtime query fields expose the selector API.
+
+## Existing actions remain valid
+
+This release does not remove or reinterpret `.query()`:
+
+```ts
+await this.model.products.query({ page, filter })
+await this.model.products.refetch()
+this.model.products.set(serverData)
+```
+
+Use selector `.load()` when the mounted view owns the request. Keep action methods for user commands, preloads, forced requests, multi-query coordination, and side effects. Existing `useEffect`-driven loading remains compatible.
+
+No additional React hook was added; the feature is part of the selector accepted by `useModel()` and hooks returned by `create()`.
+
+## Server Suspense guidance
+
+The documentation now includes a cache-aware App Router fallback pattern. A client fallback can passively render an already successful active query and otherwise show a skeleton; the resolved server branch initializes the resource with `silent(() => resource.set(data))`.
+
+This uses existing query state and server initialization. A separate hydration API is not required.
+
+## Documentation for agents
+
+`/llms.txt` has been rewritten as a compact, end-to-end implementation guide. It now covers the same practical domain workflow as the project state guide: types-first structure, query ownership, server initialization, CRUD consistency, cross-domain actions, optimistic rollback, proxy boundaries, decorators, persistence, history, and delivery checks.
+
+## Upgrade
+
+```bash
+yarn add @comwit/state@2.1.0
+```
+
+The deprecated `comwit` compatibility package also tracks v2.1.0 and re-exports `@comwit/state`.
+
+[GitHub Release](https://github.com/burrr-ai/comwit/releases/tag/v2.1.0) | [npm](https://www.npmjs.com/package/@comwit/state)

--- a/apps/docs/content/docs/api/create.mdx
+++ b/apps/docs/content/docs/api/create.mdx
@@ -54,18 +54,17 @@ const { posts } = usePost((s) => ({ posts: s.posts }))
 
 ## Reading query fields
 
-Query fields expose data and status flags:
+Call `.load(arg)` in the selector when the mounted component owns the request. It returns the query state and makes the first render loading-aware:
 
 ```tsx
-const { posts, actions } = usePost((s) => ({
-  posts: s.posts,
-  actions: s.actions,
-}))
+const posts = usePost((s) => s.posts.load({ page }))
 
 if (posts.isLoading) return <Skeleton />
 if (posts.isError) return <p>Error: {posts.error}</p>
 return posts.data.map((post) => <Card key={post.id} post={post} />)
 ```
+
+Selecting `s.posts` without `.load(...)` only observes existing state; it does not fetch. Existing action-driven loading remains valid for commands and coordinated workflows.
 
 ## Calling actions
 
@@ -78,3 +77,5 @@ useEffect(() => {
   actions.loadPosts()
 }, [])
 ```
+
+The effect pattern is backward compatible. Prefer selector `.load(...)` for a request whose argument already comes from render props or route state, because the query key is known during the first render and no empty state flashes before the effect.

--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -37,15 +37,48 @@ export type PostState = {
 }
 ```
 
+## Load from a selector
+
+Inside `useModel()` or a hook created by `create()`, call `.load(arg)` on the query field to declare that this component needs that query:
+
+```tsx
+const list = useProduct((state) => state.products.load({ page, filter }))
+
+if (list.isLoading) return <Skeleton />
+if (list.isError) return <ErrorMessage message={list.error} />
+return <ProductList products={list.data.items} />
+```
+
+The argument type is inferred from `Query<Data, Arg>`. Queries without an argument use `.load()`.
+
+`load` is explicit and lifecycle-managed:
+
+- It reports `isLoading: true` on the first render, then starts the request after the component commits. This prevents an empty-state flash before an effect calls an action.
+- The serialized argument is the cache key. Changing it loads the new key; ordinary rerenders with the same key do not restart the request.
+- Concurrent selector loads for the same resource and key share the in-flight request.
+- Selecting `state.products` without calling `.load(...)` is passive and never starts a request.
+- `load` has no call-time options. Put defaults on `query(...)` or `ComwitProvider`; use an action with `.query(...)`, `.refetch()`, or `.set()` for imperative workflows.
+
+```tsx
+const useDashboard = create(dashboard, { actions: [dashboardActions] })
+
+const total = useDashboard((state) => state.total.load()) // Query<number>
+const list = useDashboard((state) => state.list.load({ page })) // Query<List, { page: number }>
+const cached = useDashboard((state) => state.list) // passive read
+```
+
+Existing effect-driven actions remain supported. Use selector `load` when the request belongs to the mounted view; use action `.query()` when loading is part of a command, sequence, preload, or user event.
+
 ## Methods
 
-Once accessed via `state()` in an action, query fields expose these methods:
+Inside React selectors, a query exposes `.load(arg?)` and returns its query state. Once accessed via `state()` in an action, it exposes these imperative methods:
 
-| Method         | Description                                              |
-| -------------- | -------------------------------------------------------- |
-| `.query(arg?)` | Fetch data. Respects staleTime — skips if data is fresh. |
-| `.refetch()`   | Force re-fetch with the last used argument.              |
-| `.set(data)`   | Manually set data (for optimistic updates).              |
+| Method         | Where    | Description                                                        |
+| -------------- | -------- | ------------------------------------------------------------------ |
+| `.load(arg?)`  | Selector | Declare the query for this mounted component and return its state. |
+| `.query(arg?)` | Action   | Fetch data. Respects staleTime — skips if data is fresh.           |
+| `.refetch()`   | Action   | Force re-fetch with the last used argument.                        |
+| `.set(data)`   | Action   | Manually set data and mark the query successful.                   |
 
 ## Status flags
 
@@ -135,6 +168,8 @@ async loadMoreTrending() {
   await this.model.trending.nextFetch()
 }
 ```
+
+The initial infinite query can also be declared with `.load(arg?)` in a React selector. Continue to call `.nextFetch()` and `.previousFetch()` from actions.
 
 The `queryFn` return value can include `cursor` and `hasMore` to control pagination:
 
@@ -347,3 +382,20 @@ function Page() {
 - `refetch()` does **not** suspend — uses background fetching with `isFetching`
 - Errors are thrown to the nearest `ErrorBoundary`
 - Use `Query.Suspense<T>` or `Query.SuspenseInfinite<T>` for correct typing (`data` is `NonNullable`)
+
+For App Router server streaming, prefer a cache-aware fallback instead of making every fallback a skeleton. A client fallback may passively read an already successful query and render it; otherwise it renders the skeleton. When the server result resolves, initialize the same query with `silent(() => resource.set(data))`. No separate hydration API is required.
+
+```tsx
+function ProductFallback() {
+  const detail = useProduct((state) => state.detail) // passive cache read
+  return detail.isSuccess ? <ProductView product={detail.data!} /> : <ProductSkeleton />
+}
+
+function ProductInit({ product }: { product: Product }) {
+  const actions = useProduct((state) => state.actions)
+  actions.init(product) // init uses silent(() => model.detail.set(product))
+  return <ProductView product={product} />
+}
+```
+
+Only reuse cached content when the active value is valid for the route being rendered. Otherwise use a neutral fallback.

--- a/apps/docs/content/docs/guide/structure.mdx
+++ b/apps/docs/content/docs/guide/structure.mdx
@@ -52,7 +52,7 @@ export type PostState = {
 }
 
 export type PostActions = {
-  /** @description Fetch posts via query() */
+  /** @description Imperatively fetch posts for coordinated workflows */
   loadPosts(): Promise<void>
   /** @description Toggle like. Optimistic update on list + current */
   like(postId: string): Promise<void>
@@ -62,6 +62,8 @@ export type PostActions = {
 - `Query<Data>` for client-fetched fields — provides `.data`, `.isLoading`, `.isError`, `.error`
 - `Query<Data, Arg>` — second generic is the `queryFn` parameter type
 - Plain types for SSR-hydrated or local state
+
+For view-owned requests, components can call `s.posts.load(arg)` directly in the existing domain hook selector. Keep a `loadPosts()` action when fetching is part of a command, multi-query sequence, preload, or user event. No additional hook is needed.
 
 ## Cross-domain access
 

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -1,6 +1,6 @@
 # comwit — Query System Reference
 
-> Full API reference for `query()`, `query.infinite()`, `query.realtime()`, Suspense support, caching, and resource state.
+> Full API reference for selector `.load()`, imperative query methods, `query.infinite()`, `query.realtime()`, Suspense, caching, and resource state.
 
 ## query(opts)
 
@@ -23,25 +23,27 @@ export const post = model<PostState>({
 
 ### Options
 
-| Option            | Type                                        | Description                                                          |
-| ----------------- | ------------------------------------------- | -------------------------------------------------------------------- |
-| `initialData`     | `TData`                                     | **Required.** Initial value before any fetch.                        |
-| `queryFn`         | `(arg, context) => TData \| Promise<TData>` | **Required.** Fetcher function.                                      |
-| `suspense`        | `boolean`                                   | Enable React Suspense integration. Default `false`.                  |
-| `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0`.    |
+| Option            | Type                                        | Description                                                                                        |
+| ----------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `initialData`     | `TData`                                     | **Required.** Initial value before any fetch.                                                      |
+| `queryFn`         | `(arg, context) => TData \| Promise<TData>` | **Required.** Fetcher function.                                                                    |
+| `suspense`        | `boolean`                                   | Enable React Suspense integration. Default `false`.                                                |
+| `staleTime`       | `number`                                    | Milliseconds before cached data is considered stale. Default `0`.                                  |
 | `gcTime`          | `number`                                    | Milliseconds a cache entry survives after the model loses its last observer. Default `5 * 60_000`. |
-| `placeholderData` | `TData \| (arg, previousData) => TData`     | Data shown while fetching. Use `keepPreviousData` helper.            |
+| `placeholderData` | `TData \| (arg, previousData) => TData`     | Data shown while fetching. Use `keepPreviousData` helper.                                          |
 
 ### queryFn Signature
 
 ```ts
-queryFn: (arg: TArg, context: { state: Readonly<ResourceSingleState<TData>> }) => TData | Promise<TData>
+queryFn: (arg: TArg, context: { state: Readonly<ResourceSingleState<TData>> }) =>
+  TData | Promise<TData>
 ```
 
 - `arg` — the argument passed to `.query(arg)`. Type is the second generic: `Query<TData, TArg>`.
 - `context.state` — a readonly snapshot of the current resource state (includes `data`, `isLoading`, etc.).
 
 The return value can be:
+
 - Plain data (`TData`) — assigned to `.data`
 - An object with `data` key plus optional state overrides
 
@@ -100,21 +102,21 @@ export const chat = model<ChatState>({
 
 ### Options
 
-| Option      | Type                                        | Description                                         |
-| ----------- | ------------------------------------------- | --------------------------------------------------- |
-| `initialData` | `TData`                                   | **Required.** Initial value before any fetch.       |
-| `queryFn`   | `(arg, context) => TData \| Promise<TData>` | **Required.** Initial data fetcher.                 |
-| `subscribe` | `(callbacks) => () => void`                 | **Required.** Sets up live subscription. Returns cleanup function. |
+| Option        | Type                                        | Description                                                        |
+| ------------- | ------------------------------------------- | ------------------------------------------------------------------ |
+| `initialData` | `TData`                                     | **Required.** Initial value before any fetch.                      |
+| `queryFn`     | `(arg, context) => TData \| Promise<TData>` | **Required.** Initial data fetcher.                                |
+| `subscribe`   | `(callbacks) => () => void`                 | **Required.** Sets up live subscription. Returns cleanup function. |
 
 ### Subscribe Callbacks
 
-| Callback    | Signature                              | Description                                         |
-| ----------- | -------------------------------------- | --------------------------------------------------- |
-| `update`    | `(updater: (prev: TData) => TData) => void` | Merge data using updater function.             |
-| `set`       | `(data: TData) => void`               | Replace data entirely.                              |
-| `refetch`   | `() => void`                           | Re-execute the queryFn.                             |
-| `onStatus`  | `(status: ConnectionStatus) => void`   | Update connection status.                           |
-| `onError`   | `(error: unknown) => void`             | Set error state.                                    |
+| Callback   | Signature                                   | Description                        |
+| ---------- | ------------------------------------------- | ---------------------------------- |
+| `update`   | `(updater: (prev: TData) => TData) => void` | Merge data using updater function. |
+| `set`      | `(data: TData) => void`                     | Replace data entirely.             |
+| `refetch`  | `() => void`                                | Re-execute the queryFn.            |
+| `onStatus` | `(status: ConnectionStatus) => void`        | Update connection status.          |
+| `onError`  | `(error: unknown) => void`                  | Set error state.                   |
 
 ### ConnectionStatus
 
@@ -129,10 +131,10 @@ export const chat = model<ChatState>({
 
 ### Realtime-only Flags
 
-| Flag               | Type               | Description                              |
-| ------------------ | ------------------ | ---------------------------------------- |
-| `connectionStatus` | `ConnectionStatus` | Current connection state.                |
-| `isConnected`      | `boolean`          | `true` when status is `'connected'`.     |
+| Flag               | Type               | Description                          |
+| ------------------ | ------------------ | ------------------------------------ |
+| `connectionStatus` | `ConnectionStatus` | Current connection state.            |
+| `isConnected`      | `boolean`          | `true` when status is `'connected'`. |
 
 ### Type
 
@@ -140,7 +142,7 @@ export const chat = model<ChatState>({
 import { Query } from '@comwit/state'
 
 messages: Query.Realtime<Message[]>
-messages: Query.Realtime<Message[], string>  // with argument
+messages: Query.Realtime<Message[], string> // with argument
 ```
 
 ## Types
@@ -180,6 +182,7 @@ const post = model<PostState>({
 ```
 
 Use `Query.Suspense<T>` or `Query.SuspenseInfinite<T>` as the type. With suspense enabled:
+
 - During initial load, a Promise is thrown (caught by React `<Suspense>`).
 - On error, the error is thrown (caught by React `<ErrorBoundary>`).
 - After success, `data` is guaranteed non-nullable.
@@ -200,11 +203,30 @@ function PostList() {
 
 ## Methods
 
-All methods are available on resource fields after binding (i.e., when accessed through `state(model)` in actions or via `useModel`/`create` hooks).
+React selectors and actions intentionally expose different loading controls.
+
+### .load(arg?) — React selectors
+
+Call `.load()` only inside a `useModel()` selector or a hook created by `create()`:
+
+```tsx
+const posts = usePost((state) => state.posts.load())
+const comments = usePost((state) => state.comments.load(postId))
+```
+
+- The argument is inferred from `Query<TData, TArg>`; an argument query requires exactly that type, while `Query<TData>` uses `.load()`.
+- Calling `.load(arg)` opts the selector into automatic loading. Merely selecting `state.posts` is passive and never fetches.
+- The selector returns the normal resource state (`data`, flags, error, plus infinite/realtime fields).
+- The request begins after React commits, but the selected state reports the first load immediately so skeleton → content does not flash through an empty state.
+- A stable mounted selector does not restart the request on unrelated rerenders. Changing the serialized argument changes the cache key and starts that key.
+- Concurrent selector loads for the same resource and key are deduplicated.
+- Call-time options are deliberately unavailable. Configure provider/query defaults, or use an action method below for forced or coordinated requests.
+
+Selector loading is additive. Existing `useEffect(() => actions.load(), [])` and event-driven actions continue to work.
 
 ### .query(arg?, options?)
 
-Triggers the fetch. Must be called at least once before `.refetch()` or `.nextFetch()` will work.
+Imperative action method. Triggers the fetch and must be called at least once before `.refetch()` or `.nextFetch()` will work.
 
 ```ts
 // No argument
@@ -221,6 +243,7 @@ await this.model.comments.query(postId, { staleTime: 60_000 })
 ```
 
 **Options:**
+
 - `force: boolean` — Bypass cache staleness check and always fetch.
 - `staleTime`, `gcTime`, `placeholderData` — Override defaults per call.
 
@@ -262,27 +285,27 @@ await this.model.trending.previousFetch()
 
 ## State Flags
 
-| Flag         | Type              | Description                                               |
-| ------------ | ----------------- | --------------------------------------------------------- |
-| `data`       | `TData`           | The fetched data (or `initialData` before first fetch).   |
-| `isLoading`  | `boolean`         | `true` during the initial fetch (before first success).   |
-| `isFetching` | `boolean`         | `true` during any fetch (including refetches).            |
-| `isSuccess`  | `boolean`         | `true` after at least one successful fetch.               |
-| `isError`    | `boolean`         | `true` when the last fetch failed.                        |
-| `error`      | `string \| null`  | Error message from the last failed fetch.                 |
+| Flag         | Type             | Description                                             |
+| ------------ | ---------------- | ------------------------------------------------------- |
+| `data`       | `TData`          | The fetched data (or `initialData` before first fetch). |
+| `isLoading`  | `boolean`        | `true` during the initial fetch (before first success). |
+| `isFetching` | `boolean`        | `true` during any fetch (including refetches).          |
+| `isSuccess`  | `boolean`        | `true` after at least one successful fetch.             |
+| `isError`    | `boolean`        | `true` when the last fetch failed.                      |
+| `error`      | `string \| null` | Error message from the last failed fetch.               |
 
 ### Infinite-only flags
 
-| Flag      | Type              | Description                                          |
-| --------- | ----------------- | ---------------------------------------------------- |
-| `cursor`  | `string \| null`  | Current pagination cursor.                           |
-| `hasMore` | `boolean`         | Whether more pages are available. `nextFetch()` is a no-op when `false`. |
+| Flag      | Type             | Description                                                              |
+| --------- | ---------------- | ------------------------------------------------------------------------ |
+| `cursor`  | `string \| null` | Current pagination cursor.                                               |
+| `hasMore` | `boolean`        | Whether more pages are available. `nextFetch()` is a no-op when `false`. |
 
 ## Cache Lifecycle
 
 ```
 query() defined in model
-  -> .query(arg) called in action
+  -> selector .load(arg) after commit OR action .query(arg)
     -> queryFn executes, data loaded
     -> cache entry created with key = serialized arg
     -> within staleTime -> cached data returned, no fetch
@@ -293,6 +316,7 @@ query() defined in model
 - Each unique argument produces a separate cache entry (keyed by serialized arg).
 - Switching between arguments restores the cached state for that argument.
 - `placeholderData` is applied when switching to an argument with no cache.
+- Query resources currently expose one active argument at a time. Cached entries remain per argument, but a displayed resource state represents the active key.
 
 ## keepPreviousData
 
@@ -377,11 +401,15 @@ export const feedLoader = action<Pick<FeedActions, 'loadPosts' | 'loadMore' | 'l
 })
 
 // usage in component
-const { posts, trending } = useFeed((s) => ({
-  posts: s.posts,
-  trending: s.trending,
-}))
+const posts = useFeed((s) => s.posts.load())
+const trending = useFeed((s) => s.trending.load())
 
 if (posts.isLoading) return <Skeleton />
 if (posts.isError) return <p>Error: {posts.error}</p>
 ```
+
+## Server Suspense fallback guidance
+
+For App Router streaming, a fallback does not have to be skeleton-only. Passively read the currently active query state: render cached content when `isSuccess`, otherwise render a skeleton. The resolved server branch can initialize the query through an action that runs `silent(() => resource.set(serverData))`. This uses the existing state API; no separate `hydrate()` primitive is needed.
+
+Only reuse the active cached value when it is valid for the route/identity being rendered. Otherwise use a neutral fallback.

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -1,441 +1,335 @@
-# comwit
+# comwit — AI implementation guide
 
-State management for Next.js.
+`@comwit/state` is domain-oriented React/Next.js state management. Use this file as the practical project contract; follow the linked references for exhaustive signatures.
 
-> Give this document to Claude Code. It sets up your project.
-
-## 1. Install
+## Install and provider
 
 ```bash
-npm i @comwit/state
+yarn add @comwit/state
 ```
 
-## 2. Enable Decorators
-
-Add `experimentalDecorators` to your `tsconfig.json`. Without this, Next.js production builds (SWC) will fail to parse `@OnError`, `@Retry`, etc.
-
-```jsonc
-// tsconfig.json
-{
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    // ... other options
-  },
-}
-```
-
-> **Why?** Next.js reads this flag and passes it to SWC as `jsc.parser.decorators: true`. Without it, the `@` token is not recognized and the build fails with "Unexpected token '@'". Dev mode (Turbopack) may work without it, but production builds will not.
-
-## 3. Setup Provider
-
-Create `app/providers.tsx` and wrap your root layout.
+Enable `experimentalDecorators` in `tsconfig.json` when using decorators. Wrap the client tree once:
 
 ```tsx
-// app/providers.tsx
 'use client'
 
-import { useRouter } from 'next/navigation'
-import { keepPreviousData, ComwitProvider } from '@comwit/state'
-import { ReactNode } from 'react'
-
-type AppContext = {
-  router: { push: (href: string) => void }
-}
-
-export function Providers({ children }: { children: ReactNode }) {
-  const router = useRouter()
-  const context: AppContext = { router }
-
-  return (
-    <ComwitProvider
-      context={context}
-      defaultOptions={{
-        query: {
-          staleTime: 30_000,
-          gcTime: 5 * 60_000,
-          placeholderData: keepPreviousData,
-        },
-      }}
-    >
-      {children}
-    </ComwitProvider>
-  )
-}
+<ComwitProvider
+  context={{ router }}
+  defaultOptions={{
+    query: { staleTime: 30_000, gcTime: 5 * 60_000 },
+    persist: { debounceMs: 100 },
+  }}
+>
+  {children}
+</ComwitProvider>
 ```
 
-```tsx
-// app/layout.tsx
-import { Providers } from './providers'
+Provider `context` is available to actions and lazy interceptors. Query defaults may also include `placeholderData`.
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <Providers>{children}</Providers>
-      </body>
-    </html>
-  )
-}
-```
+## Project contract
 
-## 4. Create `state/.ai.md`
-
-Create `src/state/.ai.md` (or `state/.ai.md`) with the full content below.
-
-## 5. Update `CLAUDE.md`
-
-Add this to your project's `CLAUDE.md`:
-
-```md
-## State Management
-
-This project uses comwit. When working on files in state/, always read state/.ai.md first.
-```
-
----
-
-## state/.ai.md Content
-
-Copy everything between the fences into your `state/.ai.md`:
-
-````md
-## Structure
-
-```
+```text
 state/{domain}/
-  ├── types.ts          # State + Actions types
-  ├── model.ts          # model() with initial state
-  ├── actions/
-  │   ├── crud.ts       # CRUD operations
-  │   ├── load.ts       # Data fetching via query()
-  │   ├── init.ts       # SSR hydration via silent()
-  │   └── ...           # One file per concern
-  └── index.ts          # create() hook + re-exports
+  types.ts          # State and Actions contracts; write first
+  model.ts          # model(), query(), persist(), computed()
+  actions/
+    init.ts         # server-data initialization
+    load.ts         # imperative/coordinated fetching
+    crud.ts         # mutations, optimistic updates, rollback
+    interact.ts     # domain interactions
+  index.ts          # create() domain hook and re-exports
 ```
 
-Write order: **types.ts -> model.ts -> actions/\*.ts -> index.ts**
+Write in this order: `types.ts` → `model.ts` → `actions/*` → `index.ts`.
 
-## Rules
+Rules:
 
-- Dependencies: pages → state → api (one way)
-- Pass domain objects whole: `<Card post={post} />`
-- **Server actions**: convert proxy → plain object before passing. Use `state.snapshot()` for the top-level model, and the standalone `snapshot(state.slice)` helper for nested slices.
+- Dependency direction is page → state → API/repository.
+- Keep list, detail, stats, filters, and related local UI state in the same domain when they must stay consistent.
+- Put commands and side effects in actions. UI event handlers should usually call one action.
+- Actions read other domains with `state(otherModel)` instead of receiving duplicate state as arguments.
+- Pass domain objects whole to UI (`<Card product={product} />`).
+- After CRUD, update every related view optimistically or refetch it; include rollback for failed optimistic writes.
+- Use selectors; calling a domain hook without a selector observes the whole model.
 
-## File Templates
+## types.ts
 
-### types.ts
-
-**Read this file first.** JSDoc on each field/method guides the implementation.
-
-- `Query<Data>` for client-fetched fields — provides `.data` `.isLoading` `.isError` `.error`
-- `Query<Data, Arg>` — second generic = queryFn param type
-- Plain types for SSR-hydrated fields
+Use `Query<Data, Arg>` for remotely loaded fields and ordinary types for local/server-initialized state.
 
 ```ts
-import { Query } from '@comwit/state'
+import type { Query } from '@comwit/state'
 
-export type Post = { id: string; ... }
-
-export type PostState = {
-  posts: Query<Post[]>              // client fetch
-  comments: Query<Comment[], string> // client fetch, second generic = queryFn arg
-  current: Post | null               // SSR hydrated
-  // ...
+export type ProductState = {
+  products: Query<Pageable<Product>, { page: number; filter: ProductFilter }>
+  stats: Query<ProductStats>
+  detail: Query<Product | null, { id: string }>
+  selectedIds: string[]
+  isEditMode: boolean
 }
 
-export type PostActions = {
-  /** @description Fetch posts via query() */
-  loadPosts(): Promise<void>
-  /** @description Toggle like. Optimistic on list + current, toast on error */
-  like(postId: string): Promise<void>
-  // ...
+export type ProductActions = {
+  initDetail(product: Product): void
+  refreshAll(): Promise<void>
+  loadMore(): Promise<void>
+  create(title: string): Promise<void>
+  delete(id: string): Promise<void>
+  toggleSelect(id: string): void
 }
 ```
 
-### model.ts
+Query type variants:
 
-`Query<T>` fields use `query()` with `initialData` + `queryFn`. Plain fields get default values.
+- `Query<T, Arg>` — single resource
+- `Query.Infinite<T, Arg>` — cursor/infinite resource
+- `Query.Realtime<T, Arg>` — initial fetch plus subscription
+- `Query.Suspense<T, Arg>` / `Query.SuspenseInfinite<T, Arg>` — non-null data typing with `{ suspense: true }`
+
+## model.ts
+
+The model defines data shape and fetch policy, not UI effects.
 
 ```ts
-import { model, query } from '@comwit/state'
+import { keepPreviousData, model, query } from '@comwit/state'
 
-export const post = model<PostState>({
-  posts: query<Post[]>({ initialData: [], queryFn: () => api.post.findAll() }),
-  comments: query<Comment[], string>({
-    initialData: [],
-    queryFn: (postId) => api.comment.findAll(postId),
+export const product = model<ProductState>({
+  products: query({
+    initialData: EMPTY_PAGE,
+    queryFn: ({ page, filter }) => api.product.list({ page, filter }),
+    placeholderData: keepPreviousData,
   }),
-  current: null,
+  stats: query({ initialData: EMPTY_STATS, queryFn: () => api.product.stats() }),
+  detail: query({ initialData: null, queryFn: ({ id }) => api.product.get(id) }),
+  selectedIds: [],
+  isEditMode: false,
 })
 ```
 
-History is off by default. Enable it per model when user-facing state should support undo and redo:
+Use `keepPreviousData` mainly for pagination. Each serialized query argument has a cache entry; the resource state displays one active argument at a time.
+
+### Infinite and realtime
 
 ```ts
-export const todo = model(
-  {
-    items: [] as Todo[],
-    selectedId: null as string | null,
+posts: query.infinite<Post[]>({
+  initialData: [],
+  queryFn: async (_, { state }) => {
+    const res = await api.posts.list({ cursor: state.cursor })
+    return { data: res.items, cursor: res.nextCursor, hasMore: res.hasNext }
   },
-  {
-    history: { limit: 100 },
-  }
-)
+})
 ```
 
-`history: true` uses a default limit of 100 undo entries. Pass `history: { limit }` to override the stack size.
+`query.realtime()` also requires `subscribe(callbacks) => cleanup`; callbacks are `update`, `set`, `refetch`, `onStatus`, and `onError`.
 
-#### Derived State & Validation
+### Derived state, validation, history, persistence
 
-`model()` accepts an optional second argument with `derive` and `rules`:
+- Inline derived fields: `computed(state => value)`.
+- Model option `derive`: returns named getter functions; derived values are readonly.
+- Model option `rules`: field validators; read `{ errors, isValid }` from `$validation`.
+- Model option `history: true | { limit }`: read `$history.undo()`, `redo()`, `canUndo`, `canRedo`, `ignore(fn)` through the existing domain hook. One action call is one history transaction.
+- `persist({ key, defaultValue, storage? })`: local/session/custom storage, SSR-safe, debounced, cross-tab for localStorage.
+
+## Choosing how a query starts
+
+There are two compatible paths. Do not create another query hook.
+
+### View-owned request: selector `.load(arg)`
+
+Use when props, route state, or local render state already contains the query argument.
+
+```tsx
+const products = useProduct((s) => s.products.load({ page, filter }))
+const stats = useProduct((s) => s.stats.load())
+```
+
+Contract:
+
+- `Arg` is inferred from the model's `Query<Data, Arg>`; `{ ... }` is type-checked. A no-arg query uses `.load()`.
+- Calling `.load()` is the explicit opt-in. Selecting `s.products` without it is a passive read and never fetches.
+- `.load()` returns the resource state, including `data` and flags.
+- The query key is available during render, so the first selected state is loading-aware; the request starts after commit.
+- A stable mounted selector does not restart on unrelated rerenders. An argument change selects/loads the new cache key.
+- Same-resource, same-key selector requests share the in-flight request.
+- Configure options on `query()` or the provider. `.load()` intentionally takes no call-time fetch options.
+
+This avoids the empty → skeleton → content flash caused when the first request is only started by `useEffect`.
+
+### Command-owned request: action `.query(arg)`
+
+Use for user events, preloads, multi-query sequences, forced calls, or workflows with other side effects.
 
 ```ts
-import { model, query } from '@comwit/state'
-
-export const cart = model<CartState, CartDerived>(
-  {
-    items: [],
-    coupon: '',
-  },
-  {
-    // derive: computed fields — recalculated on every read
-    derive: (state) => ({
-      total: () => state.items.reduce((sum, i) => sum + i.price * i.qty, 0),
-      itemCount: () => state.items.reduce((sum, i) => sum + i.qty, 0),
-    }),
-    // rules: per-field validation — accessed via state.$validation
-    rules: {
-      coupon: (v) => v.length <= 20 || 'Coupon too long',
-      items: (v) => v.length > 0 || 'Cart is empty',
+export const loadActions = action<Pick<ProductActions, 'refreshAll'>>(({ state }) => {
+  const m = state(product)
+  return {
+    async refreshAll() {
+      await Promise.all([m.products.refetch(), m.stats.refetch()])
     },
   }
-)
-```
-
-- Derived fields are readonly and throw if assigned.
-- Validation is accessed via `state.$validation`: `{ errors: { [field]: string | null }, isValid: boolean }`.
-
-#### History
-
-No new hook is needed. Use the existing domain hook and read `$history`:
-
-```tsx
-const { history } = useTodo((s) => ({ history: s.$history }))
-
-history.undo()
-history.redo()
-history.canUndo
-history.canRedo
-```
-
-Each action method call is one history transaction. Multiple mutations inside the method are undone together. Use `s.$history.ignore(() => { ... })` for changes that should re-render but should not be recorded. This is separate from `silent()`, which suppresses notifications.
-
-### actions/\*.ts
-
-Actions are self-contained — resolve state via `state()`, side effects via decorators/context. UI only calls.
-
-```ts
-import { action, silent, OnError, OnSuccess } from '@comwit/state'
-import { user } from '@/state/user/model'
-
-export const postActions = action<Pick<PostActions, '...'>, AppContext>(({ state, context }) => {
-  class PostActions {
-    private model = state(post)
-    private user = state(user) // cross-domain — read other model directly
-
-    // SSR hydrate — silent() suppresses re-render
-    init(data: Post) {
-      silent(() => {
-        this.model.current = data
-      })
-    }
-
-    async loadPosts() {
-      await this.model.posts.query()
-    }
-
-    // guard: check auth from user domain, not from params
-    @OnSuccess(() => context.router.push('/posts'))
-    @OnError((e) => toast.error(e instanceof Error ? e.message : 'Failed'))
-    async create(title: string) {
-      if (!this.user.me) return
-      const created = await api.post.create({ userId: this.user.me.id, title })
-      this.model.posts.data.push(created)
-    }
-  }
-  return new PostActions()
 })
 ```
 
-The pattern above can be automated with `intercept()` in lazy mode. See [Decorators](#decorators) below.
+Existing `useEffect(() => actions.load(), [])` code remains supported. Migrate only when selector ownership is clearer.
+
+## Query state and methods
+
+State:
+
+- All: `data`, `isLoading`, `isFetching`, `isSuccess`, `isError`, `error`.
+- Infinite: `cursor`, `hasMore`.
+- Realtime: `connectionStatus`, `isConnected`.
+
+Selector method:
+
+- `.load(arg?)` — lifecycle-managed initial query; returns state.
+
+Action methods from `state(model)`:
+
+- `.query(arg?, options?)` — fetch; honors cache freshness.
+- `.refetch()` — force the active/last argument; no-op before a successful initial query.
+- `.set(data | statePatch)` — set data and mark success; useful for optimistic and server initialization.
+- Infinite: `.nextFetch(arg?)`, `.previousFetch(arg?, options?)`.
+- Realtime: `.unsubscribe()`.
+
+Options: `staleTime`, `gcTime`, `placeholderData`; call-time `force`; conditions `enabled`, `dependsOn`; polling `refetchInterval`; `suspense`.
+
+`isLoading` represents a first load, while `isFetching` also covers background refetches. Render errors before data when appropriate.
+
+## actions/\*
+
+Actions own mutation, I/O coordination, navigation, toast/dialog side effects, and cross-domain access.
 
 ```ts
-// reusable guard — state() must be initialized in the factory body
+export const crudActions = action<Pick<ProductActions, 'delete'>>(({ state }) => {
+  class CrudActions {
+    private m = state(product)
+
+    @OnError((e) => toast.error(toMessage(e)))
+    async delete(id: string) {
+      if (!(await popup.confirm({ title: 'Delete this product?' }))) return
+      const before = [...this.m.products.data.items]
+      this.m.products.data.items = before.filter((item) => item.id !== id)
+      try {
+        await api.product.delete(id)
+        await Promise.all([this.m.products.refetch(), this.m.stats.refetch()])
+      } catch (error) {
+        this.m.products.data.items = before
+        throw error
+      }
+    }
+  }
+  return new CrudActions()
+})
+```
+
+Plain state is mutable inside actions: assign fields, `push`/`splice` arrays, or replace arrays with `filter`. Direct query-data mutation is also reactive; use `.set()` when replacing/initializing an entire query result and success state together.
+
+For cross-domain guards, initialize the other model once in the action or lazy interceptor factory:
+
+```ts
 const LoginRequired = intercept<AppContext>(({ state, context }) => {
-  const u = state(user)
+  const user = state(userModel)
   return {
     intercept: (execute, args) => {
-      if (!u.me) { context.router.push('/login'); return }
+      if (!user.me) return context.router.push('/login')
       return execute(...args)
     },
   }
 })
+```
 
-// replaces the manual if (!this.user.me) check above:
-@LoginRequired
-@OnSuccess(() => context.router.push('/posts'))
-async create(title: string) { /* ... */ }
+## Server data and App Router Suspense
 
-// or apply to the whole class — every method inherits the guard
-@LoginRequired
-class PostCrudActions {
-  async create(title: string) { /* ... */ }
-  async update(id: string, title: string) { /* ... */ }
-  async delete(id: string) { /* ... */ }
+No separate `hydrate()` API is needed. Initialize during client render through an action that wraps writes in `silent()`; do not delay it to an effect.
+
+```ts
+initDetail(value: Product) {
+  silent(() => this.m.detail.set(value))
 }
 ```
 
+`.set()` marks the query successful, so client fallbacks can distinguish initialized cache from `initialData`.
+
 ```tsx
-// call init outside useEffect — silent() makes it safe
-function PostDetail({ initialPost }: { initialPost: Post }) {
-  const { actions } = usePost((s) => ({ actions: s.actions }))
-  actions.init(initialPost)
-  return <Article />
+function DetailInit({ value }: { value: Product }) {
+  const init = useProduct((s) => s.actions.initDetail)
+  init(value)
+  return <ProductView product={value} />
 }
 ```
 
-### index.ts
+For a server `<Suspense>` boundary, the client fallback may passively read the current query: show cached content when `isSuccess`, otherwise show a skeleton. The resolved server branch renders `DetailInit`. Reuse cached content only when its active identity is valid for the route; otherwise keep the fallback neutral.
+
+Library `suspense: true` is available for client query suspension: initial query promises suspend, refetches use `isFetching`, and errors go to the nearest error boundary. Prefer the server-streaming pattern above for App Router server work.
+
+## index.ts and UI
 
 ```ts
-import { create } from '@comwit/state'
-import type { PostState, PostActions } from './types'
-import { post } from './model'
-import { postActions } from './actions/crud'
-
-export const usePost = create<PostState, PostActions>(post, {
-  actions: [postActions /* ... */],
+export const useProduct = create<ProductState, ProductActions>(product, {
+  actions: [initActions, loadActions, crudActions, interactActions],
 })
 ```
 
-## query() Summary
-
-`query()`, `query.infinite()`, and `query.realtime()` create resource descriptors for client-side fetching inside `model()`.
-
-- Methods: `.query(arg?)` · `.refetch()` · `.set(data)` · `.nextFetch()` · `.previousFetch()`
-- Flags: `isLoading` · `isFetching` · `isSuccess` · `isError` · `error`
-- Infinite-only: `cursor` · `hasMore`
-- Realtime methods: `.query()` · `.refetch()` · `.set()` · `.unsubscribe()`
-- Realtime-only: `connectionStatus` · `isConnected`
-- Subscribe callbacks: `update` · `set` · `refetch` · `onStatus` · `onError`
-- Options: `staleTime` · `gcTime` · `placeholderData` · `force`
-- Suspense: `Query.Suspense<T>` · `Query.SuspenseInfinite<T>` · `{ suspense: true }`
-
-For full API details, see the [Query System Reference](/llm/query.txt).
-
-## persist() Summary
-
-`persist()` creates a persisted field descriptor inside `model()`. Values are automatically synced to storage.
-
-```ts
-import { model, persist } from '@comwit/state'
-
-const settings = model({
-  theme: persist({ key: 'theme', defaultValue: 'light' }),
-  lang: persist({ key: 'lang', defaultValue: 'en', storage: 'sessionStorage' }),
-})
-```
-
-- Storage: `'localStorage'` (default) · `'sessionStorage'` · custom `PersistAdapter`
-- Features: auto-hydration · debounced write-back · cross-tab sync (localStorage) · SSR safe
-- Provider defaults: `<ComwitProvider defaultOptions={{ persist: { debounceMs: 100 } }}>`
-
-For full API details, see the [Persist Reference](/llm/persist.txt).
-
-For full undo/redo details, see the [History Reference](/llm/history.txt).
-
-## Usage
+Selectors use deep equality and can return state plus actions:
 
 ```tsx
-const { posts, current, actions } = usePost((s) => ({
-  posts: s.posts, // Query<Post[]> — has .data .isLoading .isError
-  current: s.current, // Post | null — plain state
+const { list, actions } = useProduct((s) => ({
+  list: s.products.load({ page, filter }),
   actions: s.actions,
 }))
 
-// query fields — check flags, access data via .data
-if (posts.isLoading) return <Skeleton />
-if (posts.isError) return <p>Error: {posts.error}</p>
-return posts.data.map((post) => <Card key={post.id} post={post} />)
+if (list.isLoading) return <Skeleton />
+if (list.isError) return <ErrorView message={list.error} retry={actions.refreshAll} />
+return list.data.items.map((product) => <Card key={product.id} product={product} />)
 ```
 
-Selectors use deep equality — only re-renders when selected values change.
+For passive cached/initialized state, omit `.load()`. UI handlers call actions rather than mutating state directly.
 
-## Decorators
+## Proxy boundaries
 
-All from `'comwit'`. Stack on class methods.
-
-| Decorator                       | Purpose                                                         |
-| ------------------------------- | --------------------------------------------------------------- |
-| `@OnError(fn)`                  | Error handler. Re-throw to propagate.                           |
-| `@OnSuccess(fn)`                | Success callback.                                               |
-| `@Debounce(ms)`                 | Debounce.                                                       |
-| `@Throttle(ms)`                 | Throttle.                                                       |
-| `@Authorized({ when, onDeny })` | Auth guard. `when: () => boolean \| Promise<boolean>`           |
-| `@Transaction()`                | Transactional execution (experimental, currently no-op).        |
-| `@Retry(count, options?)`       | Retry on failure with fixed or exponential backoff.             |
-| `@Queue(strategy?)`             | Concurrency control: `'drop'`, `'queue'`, or `'replace'`.       |
-| `@Log(level?)`                  | Console logging of calls, results, and errors.                  |
-| `@Validate(validators)`         | Argument validation before execution. Throws `ValidationError`. |
-
-`intercept(hooks | factory)` — create custom decorators with lifecycle hooks. Supports immediate mode (hooks object) and lazy mode (factory with `state`/`context` access).
-
-Global interceptors via `<ComwitProvider defaultOptions={{ interceptors: [...] }}>`.
-
-For full API details, see the [Decorator Reference](/llm/decorator.txt).
-
-## Key Concepts
-
-- `model(initial, options?)` — global reactive store, with optional `derive` and `rules`
-- `action(factory)` — factory with `state`/`context` access
-- `create(model, { actions })` — model + actions -> React hook
-- `silent(fn)` — suppress re-renders (SSR)
-- `state.snapshot()` — top-level proxy → frozen plain object. For nested slices use the standalone `snapshot(state.slice)` helper (for server actions, logging)
-- `query()` / `query.infinite()` — client fetch in model
-- `query.realtime()` — real-time subscription in model
-- `persist()` — persisted field in model
-- `state(model)` — mutable proxy in actions
-- `intercept()` — custom decorator builder (immediate or lazy mode)
-- `snapshot(state)` — non-extensible deep plain-object copy of any proxy slice (throws on non-proxy)
-- `isProxy(value)` — `true` if `value` is a comwit reactive proxy
-- `initDevTools(options?)` — dev-only devtools (`{ maxLogSize?: number }`, default 50); no-op in production
-
-## Passing State to Server Actions
-
-`state(model)` returns a Proxy, which is fine for normal use. When passing state to server actions (or other APIs that require plain objects), convert to a snapshot first.
-
-- **Top-level model**: call `.snapshot()` directly.
-- **Nested slice** (e.g. `state.filter`, `state.list.data`): use the standalone `snapshot()` helper, imported from `'comwit'`. This is the type-safe path — `.snapshot()` is only typed on the top-level proxy to keep plain assignments like `state.user = userFromApi` working.
+`state(model)` is a reactive proxy. Convert it before server actions, structured serialization, or APIs that require plain extensible objects:
 
 ```ts
 import { snapshot } from '@comwit/state'
 
-// top-level
-await savePostAction(this.model.snapshot())
-
-// nested slice
-await fetchCoders({ filter: snapshot(this.model.filter) })
+await save(this.m.snapshot()) // top-level model
+await search(snapshot(this.m.filters)) // nested slice
 ```
 
-`isProxy(value)` returns `true` for any comwit proxy (top-level model or nested slice) and `false` for plain objects or snapshots — handy in generic boundary helpers that conditionally snapshot before serializing.
+- `snapshot(proxy)` returns a frozen plain snapshot and throws for non-proxies.
+- `isProxy(value)` detects comwit proxies.
+- `silent(fn)` suppresses subscriber notifications; it is not a history-ignore helper.
 
-## References
+## Decorators and custom interception
 
-- [Query System Reference](/llm/query.txt) — query(), query.infinite(), query.realtime(), suspense, caching
-- [Decorator Reference](/llm/decorator.txt) — interceptors, guards, lifecycle hooks
-- [Persist Reference](/llm/persist.txt) — persist(), storage adapters, cross-tab sync
+Built-ins:
 
-## Feedback
+- `@OnError(fn)` — side effect, then the original error propagates automatically.
+- `@OnSuccess(fn)` — success side effect.
+- `@Authorized({ when, onDeny })` — guard.
+- `@Debounce(ms)`, `@Throttle(ms)` — timing; helpers can flush/cancel pending calls.
+- `@Retry(count, options?)` — fixed/exponential retry.
+- `@Queue('drop' | 'queue' | 'replace')` — concurrency.
+- `@Log(level?)`, `@Validate(validators)`.
 
-If you encounter a bug or have a feature request, file an issue:
-`gh issue create --repo meursyphus/comwit --title '...' --body '...'`
-````
+Use `intercept(hooks)` for context-free decorators and `intercept(({ state, context }) => hooks)` for lazy state/context access. Class decorators wrap every method; method decorators add narrower rules. If an `intercept` hook does not call `execute(...args)`, the original method is blocked.
+
+## Delivery checklist
+
+- Types written before model/actions; query argument types are explicit.
+- View-owned query uses selector `.load(arg)`; passive query intentionally omits it.
+- Command/coordinated query stays in an action.
+- Loading, error, empty, and background-fetch behavior are deliberate.
+- Server init uses `silent()` and query `.set()` where applicable.
+- CRUD keeps list/detail/stats consistent and rolls back failed optimistic writes.
+- Proxy values are snapshotted at serialization boundaries.
+- Decorator support is enabled in TypeScript/Next.js.
+
+## Full references
+
+- https://library.comwit.io/llm/query.txt — selector loading, caching, infinite, realtime, Suspense
+- https://library.comwit.io/llm/decorator.txt — decorators and `intercept`
+- https://library.comwit.io/llm/persist.txt — persistence
+- https://library.comwit.io/llm/history.txt — undo/redo
+- https://library.comwit.io/docs — human-readable documentation
+
+Feedback: `gh issue create --repo burrr-ai/comwit --title '...' --body '...'`

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "^2.0.0"
+    "@comwit/state": "^2.1.0"
   }
 }

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -9,6 +9,7 @@ import {
   Query,
   QueryDefaultOptions,
   QueryQueryOptions,
+  SelectableResourceState,
   query,
 } from './query'
 
@@ -35,18 +36,20 @@ function create<S extends object, A>(
   m: Model<S>,
   options: { actions: ActionFactory<Partial<A>, any>[] }
 ) {
+  type SelectableState = SelectableResourceState<S>
+
   function useStore(): S & { actions: A }
-  function useStore<R>(selector: (state: S & { actions: A }) => R): R
-  function useStore<R>(selector?: (state: S & { actions: A }) => R) {
+  function useStore<R>(selector: (state: SelectableState & { actions: A }) => R): R
+  function useStore<R>(selector?: (state: SelectableState & { actions: A }) => R) {
     const actions = useAction<A>(options.actions)
-    const withActions = (state: S): S & { actions: A } => ({
+    const withActions = (state: SelectableState): SelectableState & { actions: A } => ({
       ...state,
       actions,
     })
 
     const finalSelector = selector
-      ? (state: S) => selector(withActions(state))
-      : (state: S) => withActions(state) as unknown as R
+      ? (state: SelectableState) => selector(withActions(state))
+      : (state: SelectableState) => withActions(state) as unknown as R
 
     return useModel(m, finalSelector)
   }
@@ -76,6 +79,7 @@ export type {
   PlaceholderData,
   QueryDefaultOptions,
   QueryQueryOptions,
+  SelectableResourceState,
   RegistryDefaults,
   ModelOptions,
   ValidationState,

--- a/packages/comwit/src/core/model.ts
+++ b/packages/comwit/src/core/model.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import { createProxy, snapshot, subscribe } from './proxy'
 import { getPlugins, type PluginBag } from './plugin'
 import { useStoreRegistry } from './provider'
@@ -13,6 +13,20 @@ import {
   type HistoryController,
   type HistoryOptions,
 } from './history'
+import { bindResourceState } from './query/bind'
+import {
+  createQuerySelectorState,
+  querySelectorLoadKey,
+  runQuerySelectorLoads,
+  type QuerySelectorLoad,
+} from './query/select'
+import { QUERY_PLUGIN_NAME } from './query/plugin'
+import type {
+  QueryBindingRegistry,
+  QueryDefaultOptions,
+  ResourceDescriptorMap,
+  SelectableResourceState,
+} from './query/types'
 
 export type StoreEntry<T extends object = any> = {
   proxy: T
@@ -206,8 +220,14 @@ export type Model<T extends object> = {
 }
 
 export function useModel<T extends object>(m: Model<T>): T
-export function useModel<T extends object, R>(m: Model<T>, selector: (state: T) => R): R
-export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T) => R): T | R {
+export function useModel<T extends object, R>(
+  m: Model<T>,
+  selector: (state: SelectableResourceState<T>) => R
+): R
+export function useModel<T extends object, R>(
+  m: Model<T>,
+  selector?: (state: SelectableResourceState<T>) => R
+): T | R {
   if (process.env.NODE_ENV !== 'production' && !selector) {
     console.warn(
       '[comwit] useModel() without a selector subscribes to the entire state tree, ' +
@@ -218,10 +238,23 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
 
   const registry = useStoreRegistry()
   const store = registry.get(m)
+  const queryBag = m.pluginBags.get(QUERY_PLUGIN_NAME) as ResourceDescriptorMap | undefined
+  const queryRegistry = registry.pluginStates.get(QUERY_PLUGIN_NAME) as
+    | QueryBindingRegistry
+    | undefined
+  const queryDefaults = registry.pluginDefaults.get(QUERY_PLUGIN_NAME) as
+    | QueryDefaultOptions
+    | undefined
+
+  const queryController = useMemo(() => {
+    if (!queryBag?.size || !queryRegistry) return store.proxy as object
+    return bindResourceState(store.proxy, queryBag, queryDefaults, queryRegistry, m.key) as object
+  }, [m.key, queryBag, queryDefaults, queryRegistry, store])
 
   const prevRef = useRef<unknown>(null)
   const selectorRef = useRef(selector)
   selectorRef.current = selector
+  const queryLoadsRef = useRef<QuerySelectorLoad[]>([])
 
   const lifecycle = registry.getLifecycle(m)
 
@@ -253,7 +286,15 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
 
   const getSnapshot = useCallback(() => {
     const raw = store.getSnapshot()
-    const next = selectorRef.current ? selectorRef.current(raw) : raw
+    const loads: QuerySelectorLoad[] = []
+    const selectable =
+      queryBag?.size && queryRegistry
+        ? createQuerySelectorState(raw, queryController, queryBag, queryRegistry, loads)
+        : raw
+    queryLoadsRef.current = loads
+    const next = selectorRef.current
+      ? selectorRef.current(selectable as SelectableResourceState<T>)
+      : selectable
 
     if (prevRef.current !== null && isEqual(prevRef.current, next)) {
       return prevRef.current as R
@@ -261,9 +302,15 @@ export function useModel<T extends object, R>(m: Model<T>, selector?: (state: T)
 
     prevRef.current = next
     return next as R
-  }, [store])
+  }, [queryBag, queryController, queryRegistry, store])
 
   const result = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const selectorLoadKey = querySelectorLoadKey(queryLoadsRef.current)
+
+  useEffect(() => {
+    if (!queryRegistry || queryLoadsRef.current.length === 0) return
+    runQuerySelectorLoads(queryLoadsRef.current, queryRegistry)
+  }, [queryRegistry, selectorLoadKey])
 
   // Run plugin onRender hooks
   const plugins = getPlugins()

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -146,7 +146,7 @@ function stableSerialize(value: unknown, seen = new WeakSet<object>()): unknown 
   return out
 }
 
-function serializeQueryArg(arg: unknown) {
+export function serializeQueryArg(arg: unknown) {
   try {
     const serialized = JSON.stringify(stableSerialize(arg))
     return serialized === undefined ? '__undefined__' : serialized
@@ -771,5 +771,6 @@ export function createResourceAccessor(
   })
 
   registry.boundResourceValue.set(state, bound)
+  registry.boundResourceRuntime.set(bound, runtime)
   return bound
 }

--- a/packages/comwit/src/core/query/index.ts
+++ b/packages/comwit/src/core/query/index.ts
@@ -21,6 +21,10 @@ export type {
   BoundInfiniteResourceState,
   BoundRealtimeResourceState,
   BoundResourceState,
+  SelectableSingleResourceState,
+  SelectableInfiniteResourceState,
+  SelectableRealtimeResourceState,
+  SelectableResourceState,
   SingleResourceBuilderOptions,
   InfiniteResourceBuilderOptions,
   RealtimeResourceBuilderOptions,
@@ -33,7 +37,15 @@ export type {
 export { query, isResourceDescriptor, keepPreviousData } from './descriptor'
 
 // Accessor
-export { createResourceAccessor, mergeResult } from './accessor'
+export { createResourceAccessor, mergeResult, serializeQueryArg } from './accessor'
+
+// React selector auto-load
+export {
+  createQuerySelectorState,
+  runQuerySelectorLoads,
+  querySelectorLoadKey,
+  type QuerySelectorLoad,
+} from './select'
 
 // Binding
 export { bindResourceState } from './bind'

--- a/packages/comwit/src/core/query/registry.ts
+++ b/packages/comwit/src/core/query/registry.ts
@@ -11,6 +11,7 @@ export function createQueryBindingRegistry(): QueryBindingRegistry {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
     boundResourceRuntime: new WeakMap(),
+    selectorLoads: new WeakMap(),
     suspense: new Map(),
     runtimesByModel: new Map(),
   }

--- a/packages/comwit/src/core/query/select.ts
+++ b/packages/comwit/src/core/query/select.ts
@@ -1,0 +1,197 @@
+import { serializeQueryArg } from './accessor'
+import type {
+  AnyResourceDescriptor,
+  QueryBindingRegistry,
+  QueryCacheKey,
+  ResourceDataLike,
+  ResourceDescriptorMap,
+  ResourceRuntimeState,
+} from './types'
+
+export type QuerySelectorLoad = {
+  arg: unknown
+  controller: ResourceDataLike
+  hasArg: boolean
+  key: QueryCacheKey
+  path: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasNestedPath(pathMap: ResourceDescriptorMap, basePath: string) {
+  const dotPrefix = `${basePath}.`
+  const bracketPrefix = `${basePath}[`
+
+  for (const key of pathMap.keys()) {
+    if (key === basePath) return true
+    if (key.startsWith(dotPrefix)) return true
+    if (key.startsWith(bracketPrefix)) return true
+  }
+
+  return false
+}
+
+function selectorLoadsFor(
+  registry: QueryBindingRegistry,
+  controller: object
+): Map<QueryCacheKey, Promise<unknown>> | undefined {
+  return registry.selectorLoads.get(controller)
+}
+
+function pendingState(descriptor: AnyResourceDescriptor, isFetching: boolean) {
+  return Object.freeze({
+    ...descriptor.initialState,
+    isLoading: true,
+    isFetching,
+    isError: false,
+    error: null,
+  }) as ResourceDataLike
+}
+
+function cachedState(
+  state: ResourceDataLike,
+  runtime: ResourceRuntimeState | undefined,
+  controller: ResourceDataLike,
+  descriptor: AnyResourceDescriptor,
+  key: QueryCacheKey,
+  registry: QueryBindingRegistry
+): ResourceDataLike {
+  const activeEntry = runtime?.activeKey === key ? runtime.cacheEntries.get(key) : undefined
+  if (activeEntry) return state
+
+  const entry = runtime?.cacheEntries.get(key)
+  const pending = selectorLoadsFor(registry, controller)?.has(key) ?? false
+
+  if (entry?.hasQueried) {
+    return Object.freeze({
+      ...entry.state,
+      isLoading: false,
+      isFetching: pending,
+    }) as ResourceDataLike
+  }
+
+  const entryState = entry?.state
+  if (entryState?.isError === true) {
+    return entryState
+  }
+
+  return pendingState(descriptor, pending)
+}
+
+function createResourceSelector(
+  state: ResourceDataLike,
+  controller: ResourceDataLike,
+  descriptor: AnyResourceDescriptor,
+  path: string,
+  registry: QueryBindingRegistry,
+  loads: QuerySelectorLoad[]
+) {
+  return new Proxy(state, {
+    get(target, prop, receiver) {
+      if (prop !== 'load') return Reflect.get(target, prop, receiver)
+
+      return (...args: unknown[]) => {
+        const hasArg = args.length > 0
+        const arg = hasArg ? args[0] : undefined
+        const key = serializeQueryArg(arg)
+        loads.push({ arg, controller, hasArg, key, path })
+
+        const runtime = registry.boundResourceRuntime.get(controller)
+        return cachedState(state, runtime, controller, descriptor, key, registry)
+      }
+    },
+  })
+}
+
+function bindSelectorPath(
+  state: object,
+  controller: object,
+  descriptors: ResourceDescriptorMap,
+  registry: QueryBindingRegistry,
+  loads: QuerySelectorLoad[],
+  path = ''
+): object {
+  return new Proxy(state, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'symbol') return Reflect.get(target, prop, receiver)
+
+      const key = String(prop)
+      const nextPath = path ? (Array.isArray(target) ? `${path}[${key}]` : `${path}.${key}`) : key
+      const next = Reflect.get(target, prop, receiver)
+      const descriptor = descriptors.get(nextPath)
+
+      if (descriptor && isRecord(next)) {
+        const bound = Reflect.get(controller, prop, controller)
+        if (!isRecord(bound)) return next
+        return createResourceSelector(next, bound, descriptor, nextPath, registry, loads)
+      }
+
+      if (isRecord(next) && hasNestedPath(descriptors, nextPath)) {
+        const bound = Reflect.get(controller, prop, controller)
+        if (!isRecord(bound)) return next
+        return bindSelectorPath(next, bound, descriptors, registry, loads, nextPath)
+      }
+
+      return next
+    },
+  })
+}
+
+export function createQuerySelectorState<T extends object>(
+  state: T,
+  controller: object,
+  descriptors: ResourceDescriptorMap,
+  registry: QueryBindingRegistry,
+  loads: QuerySelectorLoad[]
+): T {
+  if (descriptors.size === 0) return state
+  return bindSelectorPath(state, controller, descriptors, registry, loads) as T
+}
+
+export function querySelectorLoadKey(loads: QuerySelectorLoad[]): string {
+  return JSON.stringify(loads.map(({ path, key }) => [path, key]))
+}
+
+export function runQuerySelectorLoads(
+  loads: QuerySelectorLoad[],
+  registry: QueryBindingRegistry
+): void {
+  const seen = new Set<string>()
+
+  for (const load of loads) {
+    const identity = `${load.path}\u0000${load.key}`
+    if (seen.has(identity)) continue
+    seen.add(identity)
+
+    let pending = registry.selectorLoads.get(load.controller)
+    if (!pending) {
+      pending = new Map()
+      registry.selectorLoads.set(load.controller, pending)
+    }
+    if (pending.has(load.key)) continue
+
+    const query = load.controller.query
+    if (typeof query !== 'function') continue
+
+    let promise: Promise<unknown>
+    try {
+      const result = load.hasArg
+        ? query.call(load.controller, load.arg, undefined)
+        : query.call(load.controller)
+      promise = Promise.resolve(result)
+    } catch (error) {
+      promise = Promise.reject(error)
+    }
+
+    pending.set(load.key, promise)
+    promise
+      .catch(() => {})
+      .finally(() => {
+        if (pending?.get(load.key) === promise) {
+          pending.delete(load.key)
+        }
+      })
+  }
+}

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -181,6 +181,38 @@ export type BoundInfiniteResourceState<TData, TArg = unknown> = ResourceInfinite
 export type BoundRealtimeResourceState<TData, TArg = unknown> = ResourceRealtimeState<TData> &
   ResourceRealtimeQueryController<TData, TArg>
 
+type ResourceLoadController<TState, TArg> = [TArg] extends [void]
+  ? { load(): TState }
+  : { load(arg: TArg): TState }
+
+export type SelectableSingleResourceState<TData, TArg = void> = ResourceSingleState<TData> &
+  ResourceLoadController<ResourceSingleState<TData>, TArg>
+export type SelectableInfiniteResourceState<TData, TArg = void> = ResourceInfiniteState<TData> &
+  ResourceLoadController<ResourceInfiniteState<TData>, TArg>
+export type SelectableRealtimeResourceState<TData, TArg = void> = ResourceRealtimeState<TData> &
+  ResourceLoadController<ResourceRealtimeState<TData>, TArg>
+
+type SuspenseSelectableSingleResourceState<TData, TArg = void> = Omit<
+  SelectableSingleResourceState<TData, TArg>,
+  'data' | 'load'
+> & {
+  data: NonNullable<TData>
+  load: ResourceLoadController<
+    Omit<ResourceSingleState<TData>, 'data'> & { data: NonNullable<TData> },
+    TArg
+  >['load']
+}
+type SuspenseSelectableInfiniteResourceState<TData, TArg = void> = Omit<
+  SelectableInfiniteResourceState<TData, TArg>,
+  'data' | 'load'
+> & {
+  data: NonNullable<TData>
+  load: ResourceLoadController<
+    Omit<ResourceInfiniteState<TData>, 'data'> & { data: NonNullable<TData> },
+    TArg
+  >['load']
+}
+
 type SuspenseSingleResourceState<TData, TArg = unknown> = Omit<
   BoundSingleResourceState<TData, TArg>,
   'data'
@@ -226,6 +258,30 @@ export type BoundResourceState<T> =
                   : T extends object
                     ? { [K in keyof T]: BoundResourceState<T[K]> }
                     : T
+
+/**
+ * Projects model state into the React selector shape. Query resources expose
+ * `.load(arg)`, which opts that selector into lifecycle-managed fetching while
+ * returning the same query state flags and data shape.
+ */
+export type SelectableResourceState<T> =
+  T extends RealtimeResourceDescriptor<infer TData, infer TArg>
+    ? SelectableRealtimeResourceState<TData, TArg>
+    : T extends InfiniteResourceDescriptor<infer TData, infer TArg, infer TSuspense>
+      ? TSuspense extends true
+        ? SuspenseSelectableInfiniteResourceState<TData, TArg>
+        : SelectableInfiniteResourceState<TData, TArg>
+      : T extends SingleResourceDescriptor<infer TData, infer TArg, infer TSuspense>
+        ? TSuspense extends true
+          ? SuspenseSelectableSingleResourceState<TData, TArg>
+          : SelectableSingleResourceState<TData, TArg>
+        : T extends (infer U)[]
+          ? SelectableResourceState<U>[]
+          : T extends (...args: any[]) => any
+            ? T
+            : T extends object
+              ? { [K in keyof T]: SelectableResourceState<T[K]> }
+              : T
 
 export type DependentQueryOptions<TData> = {
   enabled?: (state: any) => boolean
@@ -307,6 +363,8 @@ export type QueryBindingRegistry = {
   boundResourceValue: WeakMap<object, Record<string, unknown>>
   boundPathProxy: WeakMap<object, Map<string, object>>
   boundResourceRuntime: WeakMap<object, ResourceRuntimeState>
+  /** In-flight requests started by selector `.load()` calls, keyed per resource. */
+  selectorLoads: WeakMap<object, Map<QueryCacheKey, Promise<unknown>>>
   suspense: Map<string, SuspenseState>
   /**
    * Tracks every runtime created in this registry, indexed by the owning

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -18,6 +18,7 @@ export type {
   Query,
   QueryDefaultOptions,
   QueryQueryOptions,
+  SelectableResourceState,
   PlaceholderData,
   ModelOptions,
   ValidationState,

--- a/packages/comwit/tests/query-selector-load.test.tsx
+++ b/packages/comwit/tests/query-selector-load.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment happy-dom
+import React, { type ReactNode } from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, test, vi } from 'vitest'
+import { ComwitProvider, create, model, query, useModel } from '../src'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ComwitProvider>{children}</ComwitProvider>
+}
+
+describe('query selector load', () => {
+  test('loads an argument query from the selector and returns its query state', async () => {
+    const request = deferred<string[]>()
+    const queryFn = vi.fn((_arg: { category: string }) => request.promise)
+    const products = model({
+      list: query<string[], { category: string }>({
+        initialData: [],
+        queryFn,
+      }),
+    })
+
+    const { result } = renderHook(
+      () => useModel(products, (state) => state.list.load({ category: 'books' })),
+      { wrapper: Wrapper }
+    )
+
+    expect(queryFn).toHaveBeenCalledOnce()
+    expect(queryFn).toHaveBeenCalledWith({ category: 'books' }, expect.any(Object))
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isFetching).toBe(true)
+
+    await act(async () => {
+      request.resolve(['The Left Hand of Darkness'])
+      await request.promise
+    })
+
+    expect(result.current.data).toEqual(['The Left Hand of Darkness'])
+    expect(result.current.isSuccess).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isFetching).toBe(false)
+  })
+
+  test('supports an explicit load for a query without arguments', async () => {
+    const queryFn = vi.fn().mockResolvedValue(42)
+    const dashboard = model({
+      total: query<number>({ initialData: 0, queryFn }),
+    })
+
+    const { result } = renderHook(() => useModel(dashboard, (state) => state.total.load()), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(queryFn).toHaveBeenCalledOnce()
+    expect(result.current.data).toBe(42)
+  })
+
+  test('treats an option-shaped object as the declared query argument', async () => {
+    const queryFn = vi.fn(({ force }: { force: boolean }) => Promise.resolve(String(force)))
+    const search = model({
+      result: query<string, { force: boolean }>({ initialData: '', queryFn }),
+    })
+
+    const { result } = renderHook(
+      () => useModel(search, (state) => state.result.load({ force: true })),
+      { wrapper: Wrapper }
+    )
+
+    await waitFor(() => expect(result.current.data).toBe('true'))
+    expect(queryFn).toHaveBeenCalledWith({ force: true }, expect.any(Object))
+  })
+
+  test('does not load a query that is only selected as passive state', async () => {
+    const queryFn = vi.fn().mockResolvedValue(['unexpected'])
+    const products = model({
+      list: query<string[]>({ initialData: [], queryFn }),
+    })
+
+    const { result } = renderHook(() => useModel(products, (state) => state.list), {
+      wrapper: Wrapper,
+    })
+
+    await act(async () => Promise.resolve())
+    expect(queryFn).not.toHaveBeenCalled()
+    expect(result.current.data).toEqual([])
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  test('declares loading during server render without starting the request', () => {
+    const queryFn = vi.fn().mockResolvedValue(['client-only'])
+    const products = model({
+      list: query<string[]>({ initialData: [], queryFn }),
+    })
+
+    function View() {
+      const list = useModel(products, (state) => state.list.load())
+      return <span>{String(list.isLoading)}</span>
+    }
+
+    const html = renderToString(
+      <ComwitProvider>
+        <View />
+      </ComwitProvider>
+    )
+
+    expect(html).toContain('true')
+    expect(queryFn).not.toHaveBeenCalled()
+  })
+
+  test('does not refetch on unrelated rerenders with the same argument', async () => {
+    const queryFn = vi.fn(({ id }: { id: number }) => Promise.resolve({ id }))
+    const product = model({
+      detail: query<{ id: number } | null, { id: number }>({
+        initialData: null,
+        queryFn,
+      }),
+    })
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useModel(product, (state) => state.detail.load({ id })),
+      { initialProps: { id: 1 }, wrapper: Wrapper }
+    )
+
+    await waitFor(() => expect(result.current.data).toEqual({ id: 1 }))
+    rerender({ id: 1 })
+    rerender({ id: 1 })
+
+    expect(queryFn).toHaveBeenCalledOnce()
+  })
+
+  test('loads a new key when the selector argument changes', async () => {
+    const first = deferred<{ id: number }>()
+    const second = deferred<{ id: number }>()
+    const queryFn = vi.fn(({ id }: { id: number }) => (id === 1 ? first.promise : second.promise))
+    const product = model({
+      detail: query<{ id: number } | null, { id: number }>({
+        initialData: null,
+        queryFn,
+      }),
+    })
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useModel(product, (state) => state.detail.load({ id })),
+      { initialProps: { id: 1 }, wrapper: Wrapper }
+    )
+
+    await act(async () => {
+      first.resolve({ id: 1 })
+      await first.promise
+    })
+    expect(result.current.data).toEqual({ id: 1 })
+
+    rerender({ id: 2 })
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    expect(result.current.data).toBe(null)
+    expect(result.current.isLoading).toBe(true)
+
+    await act(async () => {
+      second.resolve({ id: 2 })
+      await second.promise
+    })
+    expect(result.current.data).toEqual({ id: 2 })
+  })
+
+  test('reuses a fresh cached key when returning to a previous argument', async () => {
+    const queryFn = vi.fn(({ id }: { id: number }) => Promise.resolve({ id }))
+    const product = model({
+      detail: query<{ id: number } | null, { id: number }>({
+        initialData: null,
+        staleTime: 10_000,
+        queryFn,
+      }),
+    })
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useModel(product, (state) => state.detail.load({ id })),
+      { initialProps: { id: 1 }, wrapper: Wrapper }
+    )
+
+    await waitFor(() => expect(result.current.data).toEqual({ id: 1 }))
+    rerender({ id: 2 })
+    await waitFor(() => expect(result.current.data).toEqual({ id: 2 }))
+    rerender({ id: 1 })
+    await waitFor(() => expect(result.current.data).toEqual({ id: 1 }))
+
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  test('deduplicates concurrent selector loads for the same resource and key', async () => {
+    const request = deferred<string[]>()
+    const queryFn = vi.fn(() => request.promise)
+    const products = model({
+      list: query<string[]>({ initialData: [], queryFn }),
+    })
+
+    renderHook(
+      () => ({
+        first: useModel(products, (state) => state.list.load()),
+        second: useModel(products, (state) => state.list.load()),
+      }),
+      { wrapper: Wrapper }
+    )
+
+    expect(queryFn).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      request.resolve(['shared'])
+      await request.promise
+    })
+  })
+
+  test('surfaces rejected selector loads as query state without an unhandled rejection', async () => {
+    const queryFn = vi.fn().mockRejectedValue(new Error('Network failure'))
+    const products = model({
+      list: query<string[]>({ initialData: [], queryFn }),
+    })
+
+    const { result } = renderHook(() => useModel(products, (state) => state.list.load()), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe('Network failure')
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.isFetching).toBe(false)
+  })
+
+  test('works through create() without adding another hook', async () => {
+    const catalog = model({
+      list: query<string[], { page: number }>({
+        initialData: [],
+        queryFn: ({ page }) => Promise.resolve([`page-${page}`]),
+      }),
+    })
+    const useCatalog = create(catalog, { actions: [] })
+
+    const { result } = renderHook(() => useCatalog((state) => state.list.load({ page: 2 }).data), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current).toEqual(['page-2']))
+  })
+})

--- a/packages/comwit/tests/snapshot-types.test.ts
+++ b/packages/comwit/tests/snapshot-types.test.ts
@@ -1,5 +1,14 @@
 import { expectTypeOf, test } from 'vitest'
-import { action, model, query, snapshot } from '../src'
+import {
+  action,
+  create,
+  model,
+  query,
+  snapshot,
+  useModel,
+  type SelectableResourceState,
+} from '../src'
+import type { Query } from '../src'
 import { createProxy } from '../src/core/proxy'
 
 // `.snapshot()` is exposed on the top-level proxy at the type level. For
@@ -94,3 +103,47 @@ test('history-enabled models expose $history methods', () => {
     return {}
   })
 })
+
+test('selector load infers query arguments from the model', () => {
+  type CatalogState = SelectableResourceState<{
+    list: Query<string[], { page: number; filter?: string }>
+    total: Query<number>
+  }>
+
+  expectTypeOf<CatalogState['list']['load']>().parameter(0).toEqualTypeOf<{
+    page: number
+    filter?: string
+  }>()
+  expectTypeOf<Parameters<CatalogState['list']['load']>>().toEqualTypeOf<
+    [{ page: number; filter?: string }]
+  >()
+  expectTypeOf<Parameters<CatalogState['total']['load']>>().toEqualTypeOf<[]>()
+  expectTypeOf<ReturnType<CatalogState['list']['load']>['data']>().toEqualTypeOf<string[]>()
+})
+
+const selectorModel = model({
+  list: query<string[], { page: number }>({
+    initialData: [],
+    queryFn: ({ page }) => Promise.resolve([String(page)]),
+  }),
+  total: query<number>({ initialData: 0, queryFn: () => Promise.resolve(1) }),
+})
+const useSelectorModel = create(selectorModel, { actions: [] })
+
+function selectorLoadTypeContract() {
+  useModel(selectorModel, (state) => state.list.load({ page: 1 }).data)
+  useSelectorModel((state) => state.total.load().data)
+
+  // @ts-expect-error argument queries require their inferred argument
+  useModel(selectorModel, (state) => state.list.load())
+  // @ts-expect-error no-argument queries do not accept an argument
+  useSelectorModel((state) => state.total.load({ page: 1 }))
+
+  // `.load()` is collected only while a selector executes.
+  // @ts-expect-error the selector-less result is passive
+  useModel(selectorModel).list.load({ page: 1 })
+  // @ts-expect-error the selector-less domain hook result is passive
+  useSelectorModel().total.load()
+}
+
+void selectorLoadTypeContract


### PR DESCRIPTION
## Summary

- add type-inferred `resource.load(arg)` inside `useModel` and `create()` selectors
- make selector loading explicit: omitting `.load()` remains a passive read with no request
- declare loading on the first render, start the request after commit, deduplicate matching in-flight loads, and react to serialized argument changes
- preserve existing action `.query()`, `.refetch()`, `.set()`, and effect-driven workflows
- document view-owned versus command-owned loading and the cache-aware App Router Suspense fallback pattern
- rewrite `llms.txt` as a compact English domain implementation guide
- prepare both packages and English release notes for v2.1.0

Closes #77.

## API

```tsx
const list = useProduct((state) =>
  state.products.load({ page, filter })
)

const stats = useProduct((state) => state.stats.load())
const cached = useProduct((state) => state.products) // passive
```

The argument is inferred from `Query<Data, Arg>`. `.load()` has no call-time options; imperative or coordinated work stays in actions.

## Validation

- `yarn workspace @comwit/state typecheck`
- `yarn workspace @comwit/state vitest run --typecheck tests/snapshot-types.test.ts`
- `yarn workspace @comwit/state test` — 25 files, 345 tests
- `yarn workspace @comwit/state build`
- `yarn workspace docs build`
- package tarball contents checked for `@comwit/state@2.1.0` and `comwit@2.1.0`

## Existing repository check failures

- docs lint still reports pre-existing errors in `app/docs/toc.tsx` and `app/page.tsx`
- the workspace build reaches the existing playground and fails in its Next 15 `/500` prerender with a React `useContext` error; the library and docs production builds pass independently