### PR TITLE
feat(local): add standalone IndexedDB resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ https://library.comwit.io/llms.txt
 
 Pass the URL to Claude Code. It handles the rest.
 
-The `2.2` beta adds normalized IndexedDB-backed, on-demand query views through
-[`local(query(...))`](https://library.comwit.io/docs/api/local).
+The `2.2` beta adds normalized IndexedDB-backed standalone resources through `local()`, plus
+query-backed revalidation through [`local.query()` and `local.infinite()`](https://library.comwit.io/docs/api/local).

--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ https://library.comwit.io/llms.txt
 ```
 
 Pass the URL to Claude Code. It handles the rest.
+
+The `2.2` beta adds normalized IndexedDB-backed, on-demand query views through
+[`local(query(...))`](https://library.comwit.io/docs/api/local).

--- a/apps/docs/content/blog/v2.2.0-beta.0-release.mdx
+++ b/apps/docs/content/blog/v2.2.0-beta.0-release.mdx
@@ -1,0 +1,86 @@
+---
+title: 'comwit v2.2.0-beta.0 — Durable on-demand queries'
+date: '2026-08-16'
+description: 'The 2.2 beta adds local.collection() and local(query()) for normalized IndexedDB snapshots, instant exact-argument hydration, and background server revalidation.'
+author: 'Codex'
+---
+
+## Query data can now survive a reload
+
+`local()` adds an IndexedDB-backed layer to the existing query resource without introducing another
+hook or mutation API:
+
+```ts
+const todos = local.collection<TodoEntity>({
+  key: 'todos',
+  version: 1,
+})
+
+const todo = model({
+  list: local(
+    query<TodoListItem[], TodoFilter>({
+      initialData: [],
+      staleTime: 30_000,
+      queryFn: api.todo.list,
+    }),
+    { source: todos }
+  ),
+  detail: local(
+    query<TodoDetail | null, string>({
+      initialData: null,
+      queryFn: api.todo.detail,
+    }),
+    { source: todos }
+  ),
+})
+```
+
+Selectors continue to call `.load(arg)`. Actions continue to use `.query()`, `.refetch()`, `.set()`,
+and direct reactive mutation.
+
+## Normalized entities, exact views
+
+The beta stores canonical entities by ID and separately stores the ordered IDs owned by each
+resource and canonical query argument. List, detail, and infinite resources can share an entity
+without pretending that a list fragment is a complete detail response.
+
+An exact durable view hydrates first. `staleTime` then decides whether to skip the request or
+revalidate in the background. A stale hit keeps `isLoading` false while `isFetching` reports the
+server check. The visible snapshot may change when that check finishes, so UIs can use `isFetching`
+for a subtle update affordance. A failed check keeps the local data visible.
+
+Unseen filters remain server requests. This is an on-demand durable query cache, not an eager full
+database.
+
+## List/detail consistency
+
+List and detail fragments shallowly merge by default. A summary response updates common fields but
+does not erase an omitted detail-only field. `merge` supports API-specific nested behavior, and an
+optional `revision` extractor rejects older server fragments.
+
+Direct entity edits write through to IndexedDB and fan out to loaded views sharing the collection
+and ID. View membership and ordering remain query-owned, so actions still refetch affected lists
+after server mutations.
+
+Responses that started before a newer local edit do not replace the edited row. This protects the
+common optimistic race while preserving the existing rollback/refetch action pattern.
+
+## Deliberate beta boundaries
+
+- Collection `version` is required. There are no migrations; bumping it invalidates and removes old
+  rows for the same scope.
+- Provider `scope` isolates users and tenants. Remount the provider when it changes.
+- `query()` and `query.infinite()` are supported; `query.realtime()` is not yet included.
+- There is no mutation outbox, offline retry queue, CRDT, or multi-device conflict engine.
+- IndexedDB failures degrade to ordinary in-memory query behavior.
+
+Use `persist()` for local-owned settings and drafts. Use `local(query())` for server-owned snapshots
+that need durable first paint and background correction.
+
+## Try the beta
+
+```bash
+yarn add @comwit/state@2.2.0-beta.0
+```
+
+See the complete [`local()` reference](/docs/api/local) before enabling it for user-scoped data.

--- a/apps/docs/content/blog/v2.2.0-beta.1-release.mdx
+++ b/apps/docs/content/blog/v2.2.0-beta.1-release.mdx
@@ -1,0 +1,87 @@
+---
+title: 'comwit v2.2.0-beta.1 — Standalone local resources'
+date: '2026-08-16'
+description: 'The second 2.2 beta separates IndexedDB resources from queries, adds exact local restore for server-rendered details, and keeps query adapters optional.'
+---
+
+The first 2.2 beta introduced normalized IndexedDB-backed query views. This update makes the
+boundary clearer: `local()` is now an independent resource, while `local.query()` and
+`local.infinite()` are optional adapters for client-owned remote loading.
+
+## Standalone server-owned detail
+
+A Next.js detail page often fetches on the server for SEO. Its Suspense fallback can now restore an
+exact IndexedDB view without starting a second API request:
+
+```ts
+const products = local.collection<Product>({ key: 'products', version: 1 })
+
+const product = model({
+  detail: local<Product | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
+})
+```
+
+```tsx
+function ProductFallback({ id }: { id: string }) {
+  const detail = useProduct((state) => state.detail.restore({ id }))
+  return detail.data ? <ProductView product={detail.data} /> : <ProductSkeleton />
+}
+```
+
+The resolved server branch initializes the same exact view:
+
+```ts
+silent(() => {
+  model.detail.set(serverProduct, { arg: { id } })
+})
+```
+
+That write updates the visible resource, canonical collection entity, loaded list rows, and
+IndexedDB. If an older restore is still pending, the server value wins.
+
+## Optional query adapters
+
+Client-owned lists retain the familiar query interface:
+
+```ts
+list: local.query<Product[], ProductFilter>({
+  source: products,
+  initialData: [],
+  staleTime: 30_000,
+  queryFn: api.product.list,
+})
+```
+
+Exact fresh views skip the request. Stale views render immediately and revalidate in the
+background. Misses use the ordinary first-load query behavior. The same pattern is available for
+infinite data with `local.infinite()`.
+
+## Lower query coupling
+
+The query implementation no longer imports local storage, IndexedDB, or collection code. It exposes
+only a generic resource lifecycle, and the local adapters attach through that boundary. Existing
+queries therefore keep their behavior without depending on the local feature.
+
+The beta.0 wrapper remains temporarily available:
+
+```ts
+local(query({ initialData: [], queryFn }), { source: products }) // deprecated
+```
+
+Prefer the explicit adapter in new code:
+
+```ts
+local.query({ source: products, initialData: [], queryFn })
+```
+
+Install the beta:
+
+```bash
+yarn add @comwit/state@2.2.0-beta.1
+```
+
+See the complete [`local()` reference](/docs/api/local) for storage identity, version invalidation,
+normalization, optimistic updates, and provider scoping.

--- a/apps/docs/content/blog/v2.2.0-beta.2-release.mdx
+++ b/apps/docs/content/blog/v2.2.0-beta.2-release.mdx
@@ -1,0 +1,56 @@
+---
+title: 'comwit v2.2.0-beta.2 — Custom local entity identity'
+date: '2026-08-16'
+description: 'The third 2.2 beta adds collection getId support and verifies that local resources degrade cleanly when IndexedDB is unavailable on the server.'
+---
+
+The third 2.2 beta lets a local collection normalize entities whose identity field is not named
+`id`.
+
+## Default and custom identity
+
+Collections continue to use `entity.id` by default:
+
+```ts
+const products = local.collection<Product>({
+  key: 'products',
+  version: 1,
+})
+```
+
+When an API uses another field, provide `getId` once on the collection:
+
+```ts
+type ExternalProduct = {
+  uuid: string
+  title: string
+}
+
+const products = local.collection<ExternalProduct>({
+  key: 'external-products',
+  version: 1,
+  getId: (product) => product.uuid,
+})
+```
+
+Normalization, IndexedDB storage, optimistic write-through, and list/detail fan-out all use the
+collection extractor. It must return the same string or finite number for every fragment of an
+entity. TypeScript requires `getId` when the entity type does not have the default `id` field.
+
+## Server behavior
+
+Server environments do not provide IndexedDB. Local resources skip that storage lifecycle without
+throwing:
+
+- standalone `local().restore()` keeps its in-memory initial or initialized value;
+- `local.query().load()` continues through the ordinary query driver;
+- browser loads still restore an exact IndexedDB view before deciding whether to revalidate.
+
+Install the beta:
+
+```bash
+yarn add @comwit/state@2.2.0-beta.2
+```
+
+See the complete [`local()` reference](/docs/api/local) for collection versions, exact argument
+views, server initialization, and synchronization behavior.

--- a/apps/docs/content/blog/v2.2.0-beta.3-release.mdx
+++ b/apps/docs/content/blog/v2.2.0-beta.3-release.mdx
@@ -1,0 +1,56 @@
+---
+title: 'comwit v2.2.0-beta.3 — Collection-scoped local data'
+date: '2026-08-17'
+description: 'The fourth 2.2 beta lets each local collection share public data or lazily derive a user/tenant scope from another model.'
+---
+
+The fourth 2.2 beta moves local persistence boundaries down to collections. Public resources can
+share one IndexedDB cache while personalized resources derive their scope from provider-bound
+state without remounting `ComwitProvider`.
+
+## Public and personalized collections
+
+Use a static scope for content shared by every visitor:
+
+```ts
+const posts = local.collection<Post>({
+  key: 'posts',
+  version: 1,
+  scope: 'public',
+})
+```
+
+Use an inline resolver for personalized data:
+
+```ts
+const projects = local.collection<Project>({
+  key: 'projects',
+  version: 1,
+  scope: ({ state }) => {
+    const userId = state(userModel).me?.id
+    return userId ? `user:${userId}` : null
+  },
+})
+```
+
+The resolver is evaluated when the resource restores, fetches, initializes, or mutates. The
+referenced model may therefore be initialized after the collection module is evaluated. Returning
+`null` or `undefined` skips IndexedDB for that operation instead of falling back to a shared scope.
+
+Collection scope takes precedence over `defaultOptions.local.scope`. Existing provider-scoped
+applications remain compatible.
+
+## Scope transitions
+
+Entity caches, exact views, optimistic revisions, version cleanup, and list/detail fan-out are all
+partitioned by the resolved collection scope. When the scope changes, the previous query cache is
+discarded. A response started under one user is not committed to another user's collection.
+
+Install the beta:
+
+```bash
+yarn add @comwit/state@2.2.0-beta.3
+```
+
+See the complete [`local()` reference](/docs/api/local) for standalone resources, query adapters,
+collection versions, exact argument views, and synchronization behavior.

--- a/apps/docs/content/blog/v2.2.0-release.mdx
+++ b/apps/docs/content/blog/v2.2.0-release.mdx
@@ -1,0 +1,81 @@
+---
+title: 'comwit v2.2.0 — Local-first resources'
+date: '2026-08-17'
+description: 'v2.2.0 adds standalone IndexedDB resources, normalized local query adapters, custom entity identity, and collection-scoped persistence.'
+author: 'Codex'
+---
+
+## Durable data without changing the model API
+
+v2.2.0 promotes the local-first resource work from beta to stable. `local()` creates a standalone
+IndexedDB-backed model field, while `local.query()` and `local.infinite()` add optional remote
+loading and revalidation to the same durable foundation.
+
+```ts
+const products = local.collection<Product>({
+  key: 'products',
+  version: 1,
+  scope: ({ state }) => {
+    const userId = state(userModel).me?.id
+    return userId ? `user:${userId}` : null
+  },
+})
+
+const productModel = model({
+  detail: local<Product | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
+  list: local.query<Product[], ProductFilter>({
+    source: products,
+    initialData: [],
+    staleTime: 30_000,
+    queryFn: api.product.list,
+  }),
+})
+```
+
+Standalone resources can restore exact persisted views and accept server-rendered initialization
+without starting a client request. Query-backed resources restore first, then use the normal
+`staleTime` rules to skip a fresh request or revalidate stale data in the background.
+
+## Normalized collections
+
+Collections store canonical entities separately from each resource and query argument's ordered
+view. List and detail fields can therefore share updates without treating a list fragment as a
+complete detail response.
+
+- Entity IDs default to `entity.id`; `getId` supports APIs that use another identity field.
+- `merge` and `revision` customize fragment merging and reject older server data.
+- Static or lazily resolved collection scopes isolate public, user, and tenant caches.
+- Scope changes discard the previous in-memory query cache and prevent cross-user response commits.
+- Direct local edits write through to IndexedDB and fan out to loaded views sharing the entity.
+
+Collection `version` remains an explicit schema boundary. There are no built-in migrations: bumping
+the version invalidates old views and cleans up older rows for that scope and collection.
+
+## Server and failure behavior
+
+Server environments simply skip IndexedDB. Standalone resources retain their initialized value,
+and query adapters continue through the ordinary query driver. Browser storage failures also
+degrade to in-memory behavior instead of breaking model access.
+
+This release does not add a mutation outbox, offline retry queue, CRDT, or multi-device conflict
+engine. Use local resources for durable first paint and client-side continuity while keeping the
+server authoritative for synchronization.
+
+## Selector compatibility fix
+
+Selector `.load()` now works when derived, computed, validation, or history extensions produce a
+frozen model snapshot. The selector binding preserves the immutable snapshot and uses a separate
+proxy target, avoiding JavaScript Proxy invariant errors.
+
+## Upgrade
+
+```bash
+yarn add @comwit/state@2.2.0
+```
+
+The deprecated `comwit` compatibility package also tracks v2.2.0 and re-exports `@comwit/state`.
+
+[npm](https://www.npmjs.com/package/@comwit/state)

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -7,68 +7,213 @@ order: 7
 
 # local()
 
-Adds an IndexedDB-backed, on-demand local view to an existing `query()` or
-`query.infinite()` resource. The public query API stays unchanged: selectors still use
-`.load(arg)`, and actions still use `.query()`, `.refetch()`, `.set()`, `nextFetch()`, and direct
-reactive mutations.
+Creates an IndexedDB-backed resource over a normalized entity collection. A local resource may be
+standalone, query-backed, or infinite-query-backed:
 
 ```ts
-import { local, model, query } from '@comwit/state'
+import { local } from '@comwit/state'
 ```
 
-`local()` is a durable normalized query cache, not a full offline sync engine. It restores an
-exact query argument from IndexedDB, shows it immediately, and revalidates stale data with the
-original `queryFn` in the background.
+```text
+local()           IndexedDB restore + server/manual set; no API driver
+local.query()     IndexedDB restore + ordinary query revalidation
+local.infinite()  IndexedDB restore + infinite query revalidation
+```
 
-## List and detail with one collection
+All forms share canonical entities by `id`, write direct optimistic mutations through to IndexedDB,
+and preserve the existing resource state shape. `local()` is not limited to client-side queries.
 
-Create one collection for an entity type, then share it across list, detail, and infinite views.
-Every entity must have a string or number `id`; IDs are detected automatically.
+## One collection, independent resources
+
+Create one collection for an entity type. IDs are detected automatically and may be strings or
+numbers.
 
 ```ts
-interface TodoEntity {
+interface ProductEntity {
   readonly id: string
   title: string
-  status: 'open' | 'done'
   updatedAt: number
   description?: string
 }
 
-type TodoListItem = Pick<TodoEntity, 'id' | 'title' | 'status' | 'updatedAt'>
-type TodoDetail = TodoEntity & { description: string }
+type ProductListItem = Pick<ProductEntity, 'id' | 'title' | 'updatedAt'>
+type ProductDetail = ProductEntity & { description: string }
 
-const todos = local.collection<TodoEntity>({
-  key: 'todos',
+const products = local.collection<ProductEntity>({
+  key: 'products',
   version: 1,
-})
-
-export const todo = model({
-  list: local(
-    query<TodoListItem[], TodoFilter>({
-      initialData: [],
-      staleTime: 30_000,
-      queryFn: (filter) => api.todo.list(filter),
-    }),
-    { source: todos }
-  ),
-
-  detail: local(
-    query<TodoDetail | null, string>({
-      initialData: null,
-      queryFn: (id) => api.todo.detail(id),
-    }),
-    { source: todos }
-  ),
+  revision: (product) => product.updatedAt,
 })
 ```
 
-The original inferred types are preserved. `list` still exposes `TodoListItem[]`, `detail` still
-exposes `TodoDetail | null`, and the resource method signatures do not change.
+Use a query adapter where the client owns remote loading, and a standalone resource where a server
+component or action supplies the value:
+
+```ts
+export const product = model({
+  list: local.query<ProductListItem[], ProductFilter>({
+    source: products,
+    initialData: [],
+    staleTime: 30_000,
+    queryFn: (filter) => api.product.list(filter),
+  }),
+
+  detail: local<ProductDetail | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
+})
+```
+
+`local.query()` retains `.load()`, `.query()`, `.refetch()`, `.set()`, and the ordinary query state.
+Standalone `local()` exposes `.restore()`, `.set()`, `.remove()`, and the same data/status fields but
+has no API driver.
+
+## App Router SEO detail and server Suspense
+
+A common detail route fetches on the server for SEO. The server `<Suspense>` fallback should not make
+another API request. It only checks whether an exact IndexedDB detail is available and otherwise
+shows a skeleton.
+
+### Model and type
+
+```ts
+import type { Local } from '@comwit/state'
+
+export type ProductState = {
+  detail: Local<ProductDetail | null, { id: string }>
+}
+
+export const product = model<ProductState>({
+  detail: local<ProductDetail | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
+})
+```
+
+### Exact cached fallback
+
+`restore(arg)` checks memory and then the exact IndexedDB view. It never invokes an API, never
+revalidates, and does not throw a Promise. While restoration is pending or misses, render the
+skeleton.
+
+```tsx
+'use client'
+
+function ProductFallback({ id }: { id: string }) {
+  const detail = useProduct((state) => state.detail.restore({ id }))
+
+  return detail.data ? <ProductView product={detail.data} /> : <ProductSkeleton />
+}
+```
+
+Passing the route identity to `restore()` prevents a previous route's active detail from appearing
+under a new URL.
+
+### Server result initialization
+
+The resolved server branch initializes the same exact view during client render. Include the
+argument because the server branch may resolve before the fallback has activated the resource.
+
+```ts
+initDetail(id: string, value: ProductDetail) {
+  silent(() => {
+    this.model.detail.set(value, {
+      arg: { id },
+    })
+  })
+}
+```
+
+```tsx
+'use client'
+
+function ProductInit({ id, value }: { id: string; value: ProductDetail }) {
+  const initDetail = useProduct((state) => state.actions.initDetail)
+  initDetail(id, value)
+  return <ProductView product={value} />
+}
+```
+
+`silent()` suppresses React notifications, not local persistence. `set()` marks the resource
+successful, writes the exact detail view and canonical entity to IndexedDB, and fans shared fields
+out to loaded product lists.
+
+```text
+server detail fetch starts
+  ├─ fallback: restore({ id })
+  │    ├─ hit  → cached detail
+  │    └─ miss → skeleton
+  └─ server resolves
+       → silent(detail.set(serverValue, { arg: { id } }))
+       → server value + IndexedDB commit
+```
+
+If an IndexedDB read is still pending when `set()` runs, its result is discarded. A late local
+restore cannot overwrite the newer server initialization.
+
+### Standalone methods
+
+| Method                  | Purpose                                                         |
+| ----------------------- | --------------------------------------------------------------- |
+| `.restore(arg)`         | Restore one exact local view; never call an API                 |
+| `.set(data, { arg })`   | Initialize or replace an exact view and write through           |
+| `.remove(arg)`          | Reset that exact view to `initialData`; does not call an API    |
+| direct `.data` mutation | Optimistically update canonical entities and loaded local views |
+
+`remove()` removes the resource view, not the server entity. Perform server deletion in an action
+and update or refetch every affected list.
+
+## Query-backed local resources
+
+`local.query()` is the local-first adapter for an ordinary query:
+
+```ts
+list: local.query<ProductListItem[], ProductFilter>({
+  source: products,
+  initialData: [],
+  staleTime: 30_000,
+  queryFn: (filter) => api.product.list(filter),
+})
+```
+
+Freshness uses the existing `staleTime` option:
+
+```text
+exact local view found and fresh
+→ show it without a network request
+
+exact local view found and stale
+→ show it immediately
+→ isLoading: false, isFetching: true
+→ run queryFn in the background
+→ commit canonical entities and current view atomically
+
+exact local view missing
+→ ordinary first-load query behavior
+```
+
+If revalidation fails, the local data remains visible with `isSuccess: true` and `isError: true`.
+Visible fields may change when the server response arrives; use `isFetching` for a subtle update
+indicator and copy actively edited forms into separate draft state.
+
+`local.infinite()` accepts the ordinary infinite query options and stores flattened ID ordering,
+cursor, `hasMore`, and cursor history:
+
+```ts
+feed: local.infinite<ProductListItem[], ProductFilter>({
+  source: products,
+  initialData: [],
+  queryFn: (filter, { state }) => api.product.feed({ ...filter, cursor: state.cursor }),
+})
+```
+
+`query.realtime()` is not supported in this beta.
 
 ## Provider setup
 
-Configure one dedicated database and a stable user or tenant scope. Remount the provider when the
-scope changes so a provider never changes identity while it is alive.
+Configure a database name and stable user or tenant scope. Remount the provider when scope changes.
 
 ```tsx
 <ComwitProvider
@@ -94,106 +239,62 @@ scope changes so a provider never changes identity while it is alive.
 | `onError`       | `(error, context) => void` | —               | Observe storage/normalization failures                      |
 | `indexedDB`     | `IDBFactory`               | browser global  | Advanced injection for tests or browser-compatible runtimes |
 
-If IndexedDB is unavailable or fails, the resource degrades to an ordinary in-memory query. A
-storage error never prevents the original `queryFn` from running.
+If IndexedDB is unavailable or fails, standalone resources retain their in-memory value and query
+adapters degrade to ordinary queries.
 
-## On-demand storage model
+## On-demand normalized storage
 
-`local()` stores normalized entities once and stores query-specific membership separately:
+Entities and exact resource views are stored separately:
 
 ```text
 entities
-  todo:1 → { id: "1", title: "A", description: "..." }
-  todo:2 → { id: "2", title: "B" }
+  product:1 → { id: "1", title: "A", description: "..." }
 
 views
-  list:{status:"open"} → ids: [1, 2], fetchedAt, ordering
-  detail:1             → ids: [1], fetchedAt
+  list:{status:"active"} → ids: [1], fetchedAt, ordering
+  detail:{id:"1"}        → ids: [1], fetchedAt
 ```
 
 The durable view key includes:
 
 ```text
 scope + collection key + collection version
-+ resource key + resource kind + canonical query argument
++ resource key + resource kind + canonical argument
 ```
 
-An exact view proves membership and completeness for that argument. An entity loaded by a list does
-not prove that its detail response was loaded, so the first `detail.load(id)` still calls the detail
-endpoint. Likewise, an unseen filter is a cache miss even when some matching entities happen to be
-present locally.
+An exact list view proves only that filter's membership. A list entity does not prove detail
+completeness, and an entity loaded elsewhere does not make an unseen filter complete. Storage is
+on-demand rather than a full local database.
 
-This is deliberately on demand:
-
-- Previously loaded exact argument: restore its IDs and entities from IndexedDB.
-- Unseen argument: call the server and create a new durable view.
-- Arbitrary offline filtering across unseen data: not supported because the full collection is not
-  present.
+Rows omitted from one filtered response lose only that view membership; they are not treated as
+global deletions because another list or detail may still reference them.
 
 ### Response envelopes
 
-For query data such as `{ items, total }`, provide `map.split/join`. Only entity rows are normalized;
-the cloneable envelope metadata stays on the view.
+For `{ items, total }` and similar shapes, provide `map.split/join`:
 
 ```ts
-page: local(
-  query<Page<TodoListItem>, TodoFilter>({
-    initialData: { items: [], total: 0 },
-    queryFn: (filter) => api.todo.page(filter),
-  }),
-  {
-    source: todos,
-    map: {
-      split: (page) => ({
-        rows: page.items,
-        meta: { total: page.total },
-      }),
-      join: (rows, meta) => ({
-        items: rows,
-        total: meta?.total ?? 0,
-      }),
-    },
-  }
-)
+page: local.query<Page<ProductListItem>, ProductFilter>({
+  source: products,
+  initialData: { items: [], total: 0 },
+  queryFn: (filter) => api.product.page(filter),
+  map: {
+    split: (page) => ({
+      rows: page.items,
+      meta: { total: page.total },
+    }),
+    join: (rows, meta) => ({
+      items: rows,
+      total: meta?.total ?? 0,
+    }),
+  },
+})
 ```
 
-`join` also lets canonical detail changes flow back into the original list envelope without changing
-its public query type.
+## Entity merging and optimistic edits
 
-## Stale-while-revalidate
-
-Freshness uses the existing query `staleTime` option. No duplicate local freshness option is added.
-
-```text
-local view found and fresh
-→ show it without a network request
-
-local view found and stale
-→ show it immediately
-→ isLoading: false, isFetching: true
-→ run the original queryFn in the background
-→ replace changed entities and view membership in one IndexedDB transaction
-
-local view not found
-→ use the ordinary query loading state and server request
-```
-
-If background revalidation fails, the local data remains visible with `isSuccess: true` and
-`isError: true`. The caller can show a non-blocking stale/offline indicator while retaining content.
-
-Because the durable snapshot is provisional, visible fields can change when the server response
-arrives. That correction is deliberate: render a subtle “checking for updates” affordance from
-`isFetching` when the change could surprise users. Do not bind an actively edited form directly to
-revalidating query data; copy it into draft state first.
-
-Server results are committed as one view snapshot. Rows missing from one filtered result lose only
-that view membership; they are not treated as global entity deletions because another list or detail
-may still reference them.
-
-## Entity merging across endpoints
-
-List and detail endpoints often return different fragments. By default, incoming own fields are
-shallowly merged into the canonical entity:
+Incoming own fields shallowly merge into the canonical entity. A list summary therefore does not
+erase an omitted detail-only field:
 
 ```text
 stored detail: { id: 1, title: "A", description: "Detail only" }
@@ -202,124 +303,78 @@ new list row:  { id: 1, title: "B" }
 merged entity: { id: 1, title: "B", description: "Detail only" }
 ```
 
-An omitted property is preserved. An explicitly returned `null` replaces the old value. Incoming
-arrays and nested objects replace their top-level field; use `merge` when an API needs a different
-rule.
+An explicit `null` replaces a field. Use collection `merge` for custom nested behavior and
+`revision` to reject an older server fragment.
 
-```ts
-const todos = local.collection<TodoEntity>({
-  key: 'todos',
-  version: 1,
-  merge(current, incoming) {
-    return {
-      ...current,
-      ...incoming,
-      author: incoming.author ? { ...current.author, ...incoming.author } : current.author,
-    }
-  },
-})
-```
-
-When list and detail endpoints include a comparable server revision, configure it to prevent an
-older endpoint response from replacing a newer entity:
-
-```ts
-const todos = local.collection<TodoEntity>({
-  key: 'todos',
-  version: 1,
-  revision: (todo) => todo.updatedAt,
-})
-```
-
-## Optimistic mutations
-
-Query data remains an ordinary comwit reactive proxy. Editing an entity writes the canonical row to
-IndexedDB and updates every loaded local resource that contains the same collection and ID.
+Direct resource mutations remain ordinary reactive proxy mutations:
 
 ```ts
 const previous = this.model.detail.data!.title
 this.model.detail.data!.title = title
 
 try {
-  await api.todo.update(id, { title })
-  await Promise.all([this.model.detail.refetch(), this.model.list.refetch()])
+  await api.product.update(id, { title })
+  await this.model.list.refetch()
 } catch (error) {
   this.model.detail.data!.title = previous
   throw error
 }
 ```
 
-The list title changes immediately because list and detail share the entity. Query membership,
-ordering, totals, and cursors are still server-owned: refetch affected views after a mutation that
-can change them.
+The changed canonical row is written through and fanned out to every loaded local resource sharing
+the collection and ID. Responses that started before a newer local edit cannot overwrite the newer
+fields or locally changed membership.
 
-Array removal changes only the active view:
+List membership, ordering, totals, and cursors remain view-owned. Refetch affected query-backed
+views after a mutation that can change them. There is no mutation outbox, offline retry queue, CRDT,
+or multi-device conflict engine.
 
-```ts
-this.model.list.data.splice(index, 1)
-```
+## Collection and resource options
 
-It does not mean “delete this entity globally” and does not erase a loaded detail. Perform the API
-delete and refetch or explicitly update all relevant resources in the action.
-
-Responses that started before a newer local edit do not overwrite the edited row. A successful API
-mutation should still end with an explicit `refetch()` to establish the final server result.
-
-`local()` does not add an outbox or retry failed mutations after a tab closes. True offline writes,
-multi-device conflict resolution, operation logs, and CRDT behavior require a sync engine.
-
-## Infinite queries
-
-`query.infinite()` is supported when `data` is an entity array. The flattened ID order, current
-cursor, `hasMore`, and cursor history are stored with the view.
-
-```ts
-feed: local(
-  query.infinite<TodoListItem[], TodoFilter>({
-    initialData: [],
-    queryFn: (filter, { state }) => api.todo.feed({ ...filter, cursor: state.cursor }),
-  }),
-  { source: todos }
-)
-```
-
-`query.realtime()` is intentionally unsupported in this beta. Its subscription and persistence
-ownership need a separate contract.
-
-## Collection options
-
-| Option     | Required | Description                                                  |
-| ---------- | -------- | ------------------------------------------------------------ |
-| `key`      | Yes      | Stable persisted entity namespace                            |
-| `version`  | Yes      | Positive integer schema version                              |
-| `merge`    | No       | Custom canonical fragment merge                              |
-| `revision` | No       | Extract comparable server revision to ignore older responses |
+| Collection option | Required | Description                          |
+| ----------------- | -------- | ------------------------------------ |
+| `key`             | Yes      | Stable persisted entity namespace    |
+| `version`         | Yes      | Positive integer schema version      |
+| `merge`           | No       | Custom canonical fragment merge      |
+| `revision`        | No       | Comparable server revision extractor |
 
 There are no migrations in this beta. Bumping `version` makes old views a cache miss and removes
-older rows for the same scope and collection. Increment it whenever the stored entity shape becomes
-incompatible.
+older rows for the same scope and collection.
 
-## Resource options
+| Resource option | Required | Description                                                            |
+| --------------- | -------- | ---------------------------------------------------------------------- |
+| `source`        | Yes      | Shared `local.collection()`                                            |
+| `initialData`   | Yes      | Value before restore/fetch                                             |
+| `key`           | No       | Stable view identity override; defaults to the model field path        |
+| `serializeArg`  | No       | Custom argument serializer; must return a collision-safe stable string |
+| `map`           | No       | Entity adapter for response envelopes                                  |
 
-| Option         | Required | Description                                                            |
-| -------------- | -------- | ---------------------------------------------------------------------- |
-| `source`       | Yes      | Shared `local.collection()`                                            |
-| `key`          | No       | Stable view identity override; defaults to the model field path        |
-| `serializeArg` | No       | Custom argument serializer; must return a collision-safe stable string |
-| `map`          | No       | `split/join` adapter for response envelopes such as `{ items, total }` |
+## Query coupling and compatibility
 
-Use `key` only when two resources share the same collection and field path but represent different
-server semantics. Normal JSON-like arguments use comwit's canonical sorted serialization.
+Query internals know only a generic resource lifecycle. They do not import `local`, IndexedDB, or
+collections. `local.query()` and `local.infinite()` install the local lifecycle adapter; standalone
+`local()` uses the same neutral resource state engine without a network driver.
+
+The beta.0 wrapper remains as a deprecated compatibility alias:
+
+```ts
+// Deprecated compatibility form
+local(query({ initialData: [], queryFn }), { source: products })
+
+// Preferred
+local.query({ source: products, initialData: [], queryFn })
+```
 
 ## `persist()` versus `local()`
 
-Use `persist()` for local-owned preferences, drafts, and UI state. Use `local(query(...))` for
-server-owned entity snapshots that should render from IndexedDB and revalidate through an API.
+Use `persist()` for local-owned preferences, drafts, and UI state. Use `local()` for server-shaped,
+ID-keyed snapshots that may be restored from IndexedDB and later initialized or corrected by a
+server source.
 
 ```text
-persist()            local(query())
-local value          server-owned snapshot
+persist()            local()
+local-owned value    server-shaped snapshot
 local/sessionStorage IndexedDB
-one value per key    normalized entities + argument views
-no queryFn           background queryFn revalidation
+one value per key    normalized entities + exact argument views
+no server identity   optional query or server-init driver
 ```

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -1,0 +1,325 @@
+---
+title: 'local()'
+group: 'API'
+slug: 'api/local'
+order: 7
+---
+
+# local()
+
+Adds an IndexedDB-backed, on-demand local view to an existing `query()` or
+`query.infinite()` resource. The public query API stays unchanged: selectors still use
+`.load(arg)`, and actions still use `.query()`, `.refetch()`, `.set()`, `nextFetch()`, and direct
+reactive mutations.
+
+```ts
+import { local, model, query } from '@comwit/state'
+```
+
+`local()` is a durable normalized query cache, not a full offline sync engine. It restores an
+exact query argument from IndexedDB, shows it immediately, and revalidates stale data with the
+original `queryFn` in the background.
+
+## List and detail with one collection
+
+Create one collection for an entity type, then share it across list, detail, and infinite views.
+Every entity must have a string or number `id`; IDs are detected automatically.
+
+```ts
+interface TodoEntity {
+  readonly id: string
+  title: string
+  status: 'open' | 'done'
+  updatedAt: number
+  description?: string
+}
+
+type TodoListItem = Pick<TodoEntity, 'id' | 'title' | 'status' | 'updatedAt'>
+type TodoDetail = TodoEntity & { description: string }
+
+const todos = local.collection<TodoEntity>({
+  key: 'todos',
+  version: 1,
+})
+
+export const todo = model({
+  list: local(
+    query<TodoListItem[], TodoFilter>({
+      initialData: [],
+      staleTime: 30_000,
+      queryFn: (filter) => api.todo.list(filter),
+    }),
+    { source: todos }
+  ),
+
+  detail: local(
+    query<TodoDetail | null, string>({
+      initialData: null,
+      queryFn: (id) => api.todo.detail(id),
+    }),
+    { source: todos }
+  ),
+})
+```
+
+The original inferred types are preserved. `list` still exposes `TodoListItem[]`, `detail` still
+exposes `TodoDetail | null`, and the resource method signatures do not change.
+
+## Provider setup
+
+Configure one dedicated database and a stable user or tenant scope. Remount the provider when the
+scope changes so a provider never changes identity while it is alive.
+
+```tsx
+<ComwitProvider
+  key={user.id}
+  defaultOptions={{
+    local: {
+      database: 'my-app',
+      scope: `user:${user.id}`,
+      onError(error, context) {
+        reportError(error, context)
+      },
+    },
+  }}
+>
+  {children}
+</ComwitProvider>
+```
+
+| Provider option | Type                       | Default         | Purpose                                                     |
+| --------------- | -------------------------- | --------------- | ----------------------------------------------------------- |
+| `database`      | `string`                   | `@comwit/state` | Dedicated IndexedDB database name                           |
+| `scope`         | `string`                   | `default`       | User/tenant boundary included in every persisted key        |
+| `onError`       | `(error, context) => void` | —               | Observe storage/normalization failures                      |
+| `indexedDB`     | `IDBFactory`               | browser global  | Advanced injection for tests or browser-compatible runtimes |
+
+If IndexedDB is unavailable or fails, the resource degrades to an ordinary in-memory query. A
+storage error never prevents the original `queryFn` from running.
+
+## On-demand storage model
+
+`local()` stores normalized entities once and stores query-specific membership separately:
+
+```text
+entities
+  todo:1 → { id: "1", title: "A", description: "..." }
+  todo:2 → { id: "2", title: "B" }
+
+views
+  list:{status:"open"} → ids: [1, 2], fetchedAt, ordering
+  detail:1             → ids: [1], fetchedAt
+```
+
+The durable view key includes:
+
+```text
+scope + collection key + collection version
++ resource key + resource kind + canonical query argument
+```
+
+An exact view proves membership and completeness for that argument. An entity loaded by a list does
+not prove that its detail response was loaded, so the first `detail.load(id)` still calls the detail
+endpoint. Likewise, an unseen filter is a cache miss even when some matching entities happen to be
+present locally.
+
+This is deliberately on demand:
+
+- Previously loaded exact argument: restore its IDs and entities from IndexedDB.
+- Unseen argument: call the server and create a new durable view.
+- Arbitrary offline filtering across unseen data: not supported because the full collection is not
+  present.
+
+### Response envelopes
+
+For query data such as `{ items, total }`, provide `map.split/join`. Only entity rows are normalized;
+the cloneable envelope metadata stays on the view.
+
+```ts
+page: local(
+  query<Page<TodoListItem>, TodoFilter>({
+    initialData: { items: [], total: 0 },
+    queryFn: (filter) => api.todo.page(filter),
+  }),
+  {
+    source: todos,
+    map: {
+      split: (page) => ({
+        rows: page.items,
+        meta: { total: page.total },
+      }),
+      join: (rows, meta) => ({
+        items: rows,
+        total: meta?.total ?? 0,
+      }),
+    },
+  }
+)
+```
+
+`join` also lets canonical detail changes flow back into the original list envelope without changing
+its public query type.
+
+## Stale-while-revalidate
+
+Freshness uses the existing query `staleTime` option. No duplicate local freshness option is added.
+
+```text
+local view found and fresh
+→ show it without a network request
+
+local view found and stale
+→ show it immediately
+→ isLoading: false, isFetching: true
+→ run the original queryFn in the background
+→ replace changed entities and view membership in one IndexedDB transaction
+
+local view not found
+→ use the ordinary query loading state and server request
+```
+
+If background revalidation fails, the local data remains visible with `isSuccess: true` and
+`isError: true`. The caller can show a non-blocking stale/offline indicator while retaining content.
+
+Because the durable snapshot is provisional, visible fields can change when the server response
+arrives. That correction is deliberate: render a subtle “checking for updates” affordance from
+`isFetching` when the change could surprise users. Do not bind an actively edited form directly to
+revalidating query data; copy it into draft state first.
+
+Server results are committed as one view snapshot. Rows missing from one filtered result lose only
+that view membership; they are not treated as global entity deletions because another list or detail
+may still reference them.
+
+## Entity merging across endpoints
+
+List and detail endpoints often return different fragments. By default, incoming own fields are
+shallowly merged into the canonical entity:
+
+```text
+stored detail: { id: 1, title: "A", description: "Detail only" }
+new list row:  { id: 1, title: "B" }
+
+merged entity: { id: 1, title: "B", description: "Detail only" }
+```
+
+An omitted property is preserved. An explicitly returned `null` replaces the old value. Incoming
+arrays and nested objects replace their top-level field; use `merge` when an API needs a different
+rule.
+
+```ts
+const todos = local.collection<TodoEntity>({
+  key: 'todos',
+  version: 1,
+  merge(current, incoming) {
+    return {
+      ...current,
+      ...incoming,
+      author: incoming.author ? { ...current.author, ...incoming.author } : current.author,
+    }
+  },
+})
+```
+
+When list and detail endpoints include a comparable server revision, configure it to prevent an
+older endpoint response from replacing a newer entity:
+
+```ts
+const todos = local.collection<TodoEntity>({
+  key: 'todos',
+  version: 1,
+  revision: (todo) => todo.updatedAt,
+})
+```
+
+## Optimistic mutations
+
+Query data remains an ordinary comwit reactive proxy. Editing an entity writes the canonical row to
+IndexedDB and updates every loaded local resource that contains the same collection and ID.
+
+```ts
+const previous = this.model.detail.data!.title
+this.model.detail.data!.title = title
+
+try {
+  await api.todo.update(id, { title })
+  await Promise.all([this.model.detail.refetch(), this.model.list.refetch()])
+} catch (error) {
+  this.model.detail.data!.title = previous
+  throw error
+}
+```
+
+The list title changes immediately because list and detail share the entity. Query membership,
+ordering, totals, and cursors are still server-owned: refetch affected views after a mutation that
+can change them.
+
+Array removal changes only the active view:
+
+```ts
+this.model.list.data.splice(index, 1)
+```
+
+It does not mean “delete this entity globally” and does not erase a loaded detail. Perform the API
+delete and refetch or explicitly update all relevant resources in the action.
+
+Responses that started before a newer local edit do not overwrite the edited row. A successful API
+mutation should still end with an explicit `refetch()` to establish the final server result.
+
+`local()` does not add an outbox or retry failed mutations after a tab closes. True offline writes,
+multi-device conflict resolution, operation logs, and CRDT behavior require a sync engine.
+
+## Infinite queries
+
+`query.infinite()` is supported when `data` is an entity array. The flattened ID order, current
+cursor, `hasMore`, and cursor history are stored with the view.
+
+```ts
+feed: local(
+  query.infinite<TodoListItem[], TodoFilter>({
+    initialData: [],
+    queryFn: (filter, { state }) => api.todo.feed({ ...filter, cursor: state.cursor }),
+  }),
+  { source: todos }
+)
+```
+
+`query.realtime()` is intentionally unsupported in this beta. Its subscription and persistence
+ownership need a separate contract.
+
+## Collection options
+
+| Option     | Required | Description                                                  |
+| ---------- | -------- | ------------------------------------------------------------ |
+| `key`      | Yes      | Stable persisted entity namespace                            |
+| `version`  | Yes      | Positive integer schema version                              |
+| `merge`    | No       | Custom canonical fragment merge                              |
+| `revision` | No       | Extract comparable server revision to ignore older responses |
+
+There are no migrations in this beta. Bumping `version` makes old views a cache miss and removes
+older rows for the same scope and collection. Increment it whenever the stored entity shape becomes
+incompatible.
+
+## Resource options
+
+| Option         | Required | Description                                                            |
+| -------------- | -------- | ---------------------------------------------------------------------- |
+| `source`       | Yes      | Shared `local.collection()`                                            |
+| `key`          | No       | Stable view identity override; defaults to the model field path        |
+| `serializeArg` | No       | Custom argument serializer; must return a collision-safe stable string |
+| `map`          | No       | `split/join` adapter for response envelopes such as `{ items, total }` |
+
+Use `key` only when two resources share the same collection and field path but represent different
+server semantics. Normal JSON-like arguments use comwit's canonical sorted serialization.
+
+## `persist()` versus `local()`
+
+Use `persist()` for local-owned preferences, drafts, and UI state. Use `local(query(...))` for
+server-owned entity snapshots that should render from IndexedDB and revalidate through an API.
+
+```text
+persist()            local(query())
+local value          server-owned snapshot
+local/sessionStorage IndexedDB
+one value per key    normalized entities + argument views
+no queryFn           background queryFn revalidation
+```

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -426,8 +426,8 @@ or multi-device conflict engine.
 | `revision`        | No                   | Comparable server revision extractor                    |
 | `scope`           | No                   | Static scope or lazy `({ state }) => string \| null`    |
 
-There are no migrations in this beta. Bumping `version` makes old views a cache miss and removes
-older rows for the same scope and collection.
+There are no built-in migrations. Bumping `version` makes old views a cache miss and removes older
+rows for the same scope and collection.
 
 | Resource option | Required | Description                                                            |
 | --------------- | -------- | ---------------------------------------------------------------------- |

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -333,6 +333,50 @@ page: local.query<Page<ProductListItem>, ProductFilter>({
 })
 ```
 
+### Collection identity versus view freshness
+
+A collection represents canonical entity identity, not an API endpoint or an IndexedDB table that
+must mirror one response. List, detail, and later enrichment responses may all share the same
+collection as long as their fragments use the same entity IDs.
+
+The resource and its exact argument own membership, ordering, metadata, and freshness. Use separate
+local resources sharing one collection when the views must be restored or revalidated on different
+schedules. Each resource can have its own `staleTime` without duplicating canonical entities.
+
+When a second request only enriches the active list and should follow that list's freshness, keep it
+inside the same `local.query()`. Query functions may return an `AsyncIterable`, so the list can render
+after the first response and receive the enriched entities after the second response:
+
+```ts
+async function* loadProjects(filter: ProjectFilter) {
+  const projects = await api.project.list(filter)
+  yield { data: projects, isLoading: false, isSuccess: true }
+
+  const statuses = await api.project.deploymentStatuses(projects.map((project) => project.id))
+  yield {
+    data: mergeDeploymentStatuses(projects, statuses),
+    isLoading: false,
+    isSuccess: true,
+  }
+}
+
+projects: local.query<Project[], ProjectFilter>({
+  source: projectEntities,
+  initialData: [],
+  staleTime: 5 * 60_000,
+  queryFn: loadProjects,
+})
+```
+
+Each yield updates the reactive query state. `isFetching` remains true until the iterable completes,
+and the completed view is committed to IndexedDB. The next fresh restore therefore includes the
+enriched fields without a separate deployment-status resource.
+
+Do not add a manual `fetchedAt` field to an entity merely to schedule this second request. The exact
+view's `staleTime` already owns that policy. Optional field presence can drive a small row-level
+loading treatment while enrichment is still in progress. Model the enrichment as a separate local
+resource only when it genuinely needs an independent durable view or freshness schedule.
+
 ## Entity merging and optimistic edits
 
 Incoming own fields shallowly merge into the canonical entity. A list summary therefore does not

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -60,6 +60,31 @@ const externalProducts = local.collection<ExternalProduct>({
 `getId` must return the same string or finite number for every list/detail fragment representing
 the entity.
 
+A collection may own its persistence scope. Use a static scope for public data, or an inline
+resolver for user/tenant data. The resolver runs only when the local resource is used, so the
+referenced model may be initialized later.
+
+```ts
+const publicPosts = local.collection<Post>({
+  key: 'posts',
+  version: 1,
+  scope: 'public',
+})
+
+const privateProjects = local.collection<Project>({
+  key: 'projects',
+  version: 1,
+  scope: ({ state }) => {
+    const userId = state(userModel).me?.id
+    return userId ? `user:${userId}` : null
+  },
+})
+```
+
+Returning `null` or `undefined` skips IndexedDB reads and writes for that operation. It never falls
+back to the provider/default scope, which prevents unresolved private data from entering a shared
+cache.
+
 Use a query adapter where the client owns remote loading, and a standalone resource where a server
 component or action supplies the value:
 
@@ -227,7 +252,9 @@ feed: local.infinite<ProductListItem[], ProductFilter>({
 
 ## Provider setup
 
-Configure a database name and stable user or tenant scope. Remount the provider when scope changes.
+Configure the shared database and optional fallback scope. A collection `scope` takes precedence.
+Remount the provider when a provider-level scope changes; model-derived collection scopes do not
+require a provider change.
 
 ```tsx
 <ComwitProvider
@@ -353,6 +380,7 @@ or multi-device conflict engine.
 | `getId`           | Without default `id` | Identity extractor; defaults to the entity's `id` field |
 | `merge`           | No                   | Custom canonical fragment merge                         |
 | `revision`        | No                   | Comparable server revision extractor                    |
+| `scope`           | No                   | Static scope or lazy `({ state }) => string \| null`    |
 
 There are no migrations in this beta. Bumping `version` makes old views a cache miss and removes
 older rows for the same scope and collection.

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -20,13 +20,14 @@ local.query()     IndexedDB restore + ordinary query revalidation
 local.infinite()  IndexedDB restore + infinite query revalidation
 ```
 
-All forms share canonical entities by `id`, write direct optimistic mutations through to IndexedDB,
-and preserve the existing resource state shape. `local()` is not limited to client-side queries.
+All forms share canonical entities by collection identity, write direct optimistic mutations
+through to IndexedDB, and preserve the existing resource state shape. `local()` is not limited to
+client-side queries.
 
 ## One collection, independent resources
 
-Create one collection for an entity type. IDs are detected automatically and may be strings or
-numbers.
+Create one collection for an entity type. A string or finite-number `id` is used by default. Supply
+`getId` when the API uses another identity field or a derived identity.
 
 ```ts
 interface ProductEntity {
@@ -45,6 +46,19 @@ const products = local.collection<ProductEntity>({
   revision: (product) => product.updatedAt,
 })
 ```
+
+```ts
+type ExternalProduct = { uuid: string; title: string }
+
+const externalProducts = local.collection<ExternalProduct>({
+  key: 'external-products',
+  version: 1,
+  getId: (product) => product.uuid,
+})
+```
+
+`getId` must return the same string or finite number for every list/detail fragment representing
+the entity.
 
 Use a query adapter where the client owns remote loading, and a standalone resource where a server
 component or action supplies the value:
@@ -240,7 +254,8 @@ Configure a database name and stable user or tenant scope. Remount the provider 
 | `indexedDB`     | `IDBFactory`               | browser global  | Advanced injection for tests or browser-compatible runtimes |
 
 If IndexedDB is unavailable or fails, standalone resources retain their in-memory value and query
-adapters degrade to ordinary queries.
+adapters degrade to ordinary queries. Server environments therefore skip the IndexedDB lifecycle
+without throwing; a server-side `local.query().load()` proceeds through its normal query driver.
 
 ## On-demand normalized storage
 
@@ -331,12 +346,13 @@ or multi-device conflict engine.
 
 ## Collection and resource options
 
-| Collection option | Required | Description                          |
-| ----------------- | -------- | ------------------------------------ |
-| `key`             | Yes      | Stable persisted entity namespace    |
-| `version`         | Yes      | Positive integer schema version      |
-| `merge`           | No       | Custom canonical fragment merge      |
-| `revision`        | No       | Comparable server revision extractor |
+| Collection option | Required             | Description                                             |
+| ----------------- | -------------------- | ------------------------------------------------------- |
+| `key`             | Yes                  | Stable persisted entity namespace                       |
+| `version`         | Yes                  | Positive integer schema version                         |
+| `getId`           | Without default `id` | Identity extractor; defaults to the entity's `id` field |
+| `merge`           | No                   | Custom canonical fragment merge                         |
+| `revision`        | No                   | Comparable server revision extractor                    |
 
 There are no migrations in this beta. Bumping `version` makes old views a cache miss and removes
 older rows for the same scope and collection.

--- a/apps/docs/content/docs/api/persist.mdx
+++ b/apps/docs/content/docs/api/persist.mdx
@@ -9,9 +9,9 @@ order: 8
 
 Declares a persisted field inside a model. Values are automatically synced to storage.
 
-For server-owned query data that should restore normalized entities from IndexedDB and revalidate
-in the background, use [`local(query(...))`](/docs/api/local) instead. `persist()` is for
-local-owned preferences, drafts, and UI values.
+For server-shaped, ID-keyed snapshots that should restore normalized entities from IndexedDB, use
+[`local()`](/docs/api/local). Add its `local.query()` adapter when the client should also revalidate
+in the background. `persist()` is for local-owned preferences, drafts, and UI values.
 
 ```ts
 import { persist } from '@comwit/state'

--- a/apps/docs/content/docs/api/persist.mdx
+++ b/apps/docs/content/docs/api/persist.mdx
@@ -2,12 +2,16 @@
 title: 'persist()'
 group: 'API'
 slug: 'api/persist'
-order: 7
+order: 8
 ---
 
 # persist()
 
 Declares a persisted field inside a model. Values are automatically synced to storage.
+
+For server-owned query data that should restore normalized entities from IndexedDB and revalidate
+in the background, use [`local(query(...))`](/docs/api/local) instead. `persist()` is for
+local-owned preferences, drafts, and UI values.
 
 ```ts
 import { persist } from '@comwit/state'

--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -13,8 +13,9 @@ Declares a client-side data fetching field inside a model.
 import { query } from '@comwit/state'
 ```
 
-Wrap a query with [`local()`](/docs/api/local) when the exact argument should restore from
-IndexedDB before stale data revalidates in the background.
+Use [`local.query()`](/docs/api/local) when the exact argument should restore from IndexedDB before
+stale data revalidates in the background. Standalone `local()` is available when a server component
+or action owns remote loading.
 
 ## Basic usage
 
@@ -76,12 +77,12 @@ Existing effect-driven actions remain supported. Use selector `load` when the re
 
 Inside React selectors, a query exposes `.load(arg?)` and returns its query state. Once accessed via `state()` in an action, it exposes these imperative methods:
 
-| Method         | Where    | Description                                                        |
-| -------------- | -------- | ------------------------------------------------------------------ |
-| `.load(arg?)`  | Selector | Declare the query for this mounted component and return its state. |
-| `.query(arg?)` | Action   | Fetch data. Respects staleTime — skips if data is fresh.           |
-| `.refetch()`   | Action   | Force re-fetch with the last used argument.                        |
-| `.set(data)`   | Action   | Manually set data and mark the query successful.                   |
+| Method                 | Where    | Description                                                                       |
+| ---------------------- | -------- | --------------------------------------------------------------------------------- |
+| `.load(arg?)`          | Selector | Declare the query for this mounted component and return its state.                |
+| `.query(arg?)`         | Action   | Fetch data. Respects staleTime — skips if data is fresh.                          |
+| `.refetch()`           | Action   | Force re-fetch with the last used argument.                                       |
+| `.set(data, { arg }?)` | Action   | Manually set data and mark success; `arg` establishes an exact resource identity. |
 
 ## Status flags
 
@@ -386,19 +387,23 @@ function Page() {
 - Errors are thrown to the nearest `ErrorBoundary`
 - Use `Query.Suspense<T>` or `Query.SuspenseInfinite<T>` for correct typing (`data` is `NonNullable`)
 
-For App Router server streaming, prefer a cache-aware fallback instead of making every fallback a skeleton. A client fallback may passively read an already successful query and render it; otherwise it renders the skeleton. When the server result resolves, initialize the same query with `silent(() => resource.set(data))`. No separate hydration API is required.
+For App Router server streaming where the server owns the detail request, prefer a standalone
+[`local()`](/docs/api/local) resource. Its client fallback calls `restore({ id })`, which checks only
+the exact IndexedDB view and does not issue another API request. The resolved server branch writes
+the exact value with `silent(() => resource.set(data, { arg: { id } }))`.
 
 ```tsx
-function ProductFallback() {
-  const detail = useProduct((state) => state.detail) // passive cache read
-  return detail.isSuccess ? <ProductView product={detail.data!} /> : <ProductSkeleton />
+function ProductFallback({ id }: { id: string }) {
+  const detail = useProduct((state) => state.detail.restore({ id }))
+  return detail.data ? <ProductView product={detail.data} /> : <ProductSkeleton />
 }
 
-function ProductInit({ product }: { product: Product }) {
+function ProductInit({ id, product }: { id: string; product: Product }) {
   const actions = useProduct((state) => state.actions)
-  actions.init(product) // init uses silent(() => model.detail.set(product))
+  actions.init(id, product) // uses silent(() => detail.set(product, { arg: { id } }))
   return <ProductView product={product} />
 }
 ```
 
-Only reuse cached content when the active value is valid for the route being rendered. Otherwise use a neutral fallback.
+If no exact value exists or restoration is pending, the fallback stays a skeleton. A server
+initializer wins over an older IndexedDB read that is still pending.

--- a/apps/docs/content/docs/api/query.mdx
+++ b/apps/docs/content/docs/api/query.mdx
@@ -13,6 +13,9 @@ Declares a client-side data fetching field inside a model.
 import { query } from '@comwit/state'
 ```
 
+Wrap a query with [`local()`](/docs/api/local) when the exact argument should restore from
+IndexedDB before stale data revalidates in the background.
+
 ## Basic usage
 
 ```ts

--- a/apps/docs/public/llm/local.txt
+++ b/apps/docs/public/llm/local.txt
@@ -62,6 +62,29 @@ export const product = model<ProductState>({
 })
 ```
 
+Collections may override the provider scope. An inline resolver is evaluated only when the local
+resource is used, so it can read a model that is initialized later:
+
+```ts
+const publicPosts = local.collection<Post>({
+  key: 'posts',
+  version: 1,
+  scope: 'public',
+})
+
+const privateProjects = local.collection<Project>({
+  key: 'projects',
+  version: 1,
+  scope: ({ state }) => {
+    const userId = state(userModel).me?.id
+    return userId ? `user:${userId}` : null
+  },
+})
+```
+
+Returning `null` or `undefined` skips IndexedDB for that operation and never falls back to a shared
+scope. Collection scope takes precedence over `defaultOptions.local.scope`.
+
 One collection may back list, detail, and infinite resources. Each resource/argument keeps an
 independent view key and freshness while canonical entity fields fan out between loaded resources.
 
@@ -155,7 +178,8 @@ actively edited forms into separate draft state.
 >
 ```
 
-Remount the provider when the user/tenant scope changes. Defaults are database
+Remount the provider when a provider-level user/tenant scope changes. A model-derived collection
+scope changes independently and does not require provider remounting. Defaults are database
 `'@comwit/state'` and scope `'default'`. IndexedDB failure leaves standalone state in memory and
 makes query adapters behave like ordinary queries. Server environments have no IndexedDB, so the
 storage lifecycle is skipped without throwing and `local.query().load()` uses its normal query
@@ -189,7 +213,8 @@ bumping it makes old views a cache miss and removes older rows for that collecti
 
 Collection options include `getId(entity)`, which defaults to `entity.id` and is required by the
 type when the entity has no `id`. It must return a stable string or finite number for every
-list/detail fragment.
+list/detail fragment. `scope` accepts a static string or a lazy `({ state }) => string | null`
+resolver.
 
 Resource options:
 

--- a/apps/docs/public/llm/local.txt
+++ b/apps/docs/public/llm/local.txt
@@ -1,51 +1,138 @@
-# local() — IndexedDB-backed on-demand queries
+# comwit — local() IndexedDB resource reference
 
-`local()` wraps an existing `query()` or `query.infinite()` without changing its public API. It is
-a normalized durable query cache: restore an exact argument from IndexedDB, render it, then use the
-original `queryFn` to revalidate stale data.
+`local()` creates an IndexedDB-backed resource over normalized entities. It is independent from
+client queries; use the query adapters only when the client should also fetch and revalidate.
 
-## Basic list/detail model
+```text
+local()           IndexedDB restore + manual/server set; no API call
+local.query()     IndexedDB restore + ordinary query revalidation
+local.infinite()  IndexedDB restore + infinite query revalidation
+```
+
+All forms keep the ordinary resource state fields (`data`, `isLoading`, `isFetching`, `isSuccess`,
+`isError`, `error`) and share canonical entity values by ID.
+
+## Collection and model
+
+Create one collection for each entity type. Entity IDs are detected automatically and may be
+strings or numbers.
 
 ```ts
-import { local, model, query } from '@comwit/state'
+import { local, model } from '@comwit/state'
+import type { Local, Query } from '@comwit/state'
 
-interface TodoEntity {
+interface ProductEntity {
   readonly id: string
   title: string
-  status: 'open' | 'done'
   updatedAt: number
   description?: string
 }
 
-type TodoListItem = Pick<TodoEntity, 'id' | 'title' | 'status' | 'updatedAt'>
-type TodoDetail = TodoEntity & { description: string }
+type ProductListItem = Pick<ProductEntity, 'id' | 'title' | 'updatedAt'>
+type ProductDetail = ProductEntity & { description: string }
 
-const todos = local.collection<TodoEntity>({
-  key: 'todos',
+const products = local.collection<ProductEntity>({
+  key: 'products',
   version: 1,
+  revision: (product) => product.updatedAt,
 })
 
-export const todo = model({
-  list: local(
-    query<TodoListItem[], TodoFilter>({
-      initialData: [],
-      staleTime: 30_000,
-      queryFn: (filter) => api.todo.list(filter),
-    }),
-    { source: todos }
-  ),
-  detail: local(
-    query<TodoDetail | null, string>({
-      initialData: null,
-      queryFn: (id) => api.todo.detail(id),
-    }),
-    { source: todos }
-  ),
+type ProductState = {
+  list: Query<ProductListItem[], ProductFilter>
+  detail: Local<ProductDetail | null, { id: string }>
+}
+
+export const product = model<ProductState>({
+  list: local.query<ProductListItem[], ProductFilter>({
+    source: products,
+    initialData: [],
+    staleTime: 30_000,
+    queryFn: (filter) => api.product.list(filter),
+  }),
+  detail: local<ProductDetail | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
 })
 ```
 
-One collection represents one entity type. List/detail/infinite resources keep independent view
-keys and freshness while sharing canonical values by `id`.
+One collection may back list, detail, and infinite resources. Each resource/argument keeps an
+independent view key and freshness while canonical entity fields fan out between loaded resources.
+
+## Standalone local methods
+
+- `.restore(arg)` — restore only the exact in-memory/IndexedDB view. It never calls an API,
+  revalidates, or suspends.
+- `.set(data, { arg })` — initialize or replace the exact view, mark success, and write entities and
+  the view to IndexedDB.
+- `.remove(arg)` — reset the exact view to `initialData`. It does not delete a server entity.
+- Direct `.data` mutation — optimistic reactive mutation that writes through and fans shared entity
+  fields out to other loaded local resources.
+
+The `arg` passed to `restore`, `set`, or `remove` is the durable identity. Always pass a route ID for
+a detail resource so another route's active value cannot appear under the current URL.
+
+## Next.js App Router SEO and Suspense fallback
+
+For SEO, fetch detail in the server component. Its client fallback does not make another API call:
+it restores the exact local view and shows cached content only when present.
+
+```tsx
+'use client'
+
+function ProductFallback({ id }: { id: string }) {
+  const detail = useProduct((state) => state.detail.restore({ id }))
+
+  return detail.data ? <ProductView product={detail.data} /> : <ProductSkeleton />
+}
+```
+
+When the server branch resolves, initialize the same exact view during client render:
+
+```ts
+initDetail(id: string, value: ProductDetail) {
+  silent(() => {
+    this.model.detail.set(value, { arg: { id } })
+  })
+}
+```
+
+`silent()` suppresses React notifications, not persistence. The server value updates IndexedDB and
+canonical list rows. If an older IndexedDB restore is still pending, it is discarded and cannot
+overwrite the server result.
+
+```text
+server detail fetch starts
+  ├─ fallback restore({ id }): exact hit → cached detail; miss/pending → skeleton
+  └─ server resolves: silent(detail.set(value, { arg: { id } }))
+                       → visible detail + canonical fanout + IndexedDB commit
+```
+
+## Query-backed local resources
+
+Use `local.query()` where a mounted client view owns remote loading. Its public interface is the
+ordinary query interface: `.load()`, `.query()`, `.refetch()`, `.set()`, and the same status fields.
+
+```ts
+list: local.query<ProductListItem[], ProductFilter>({
+  source: products,
+  initialData: [],
+  staleTime: 30_000,
+  queryFn: (filter) => api.product.list(filter),
+})
+```
+
+- Exact fresh view: restore and skip the request.
+- Exact stale view: render immediately with `isLoading: false`, set `isFetching: true`, then
+  revalidate in the background.
+- Exact miss: use ordinary first-load query behavior.
+- Revalidation error: retain local data with `isSuccess: true` and `isError: true`.
+
+Background correction may visibly change data. Use `isFetching` for a subtle indicator and copy
+actively edited forms into separate draft state.
+
+`local.infinite()` accepts ordinary infinite query options and persists flattened ID order, cursor,
+`hasMore`, and cursor history. Realtime queries are unsupported in this beta.
 
 ## Provider
 
@@ -62,61 +149,52 @@ keys and freshness while sharing canonical values by `id`.
 >
 ```
 
-Remount the provider when scope changes. Defaults are `database: '@comwit/state'` and
-`scope: 'default'`. IndexedDB failure degrades to an ordinary query.
+Remount the provider when the user/tenant scope changes. Defaults are database
+`'@comwit/state'` and scope `'default'`. IndexedDB failure leaves standalone state in memory and
+makes query adapters behave like ordinary queries.
 
-## Storage and loading
+## On-demand normalized storage
 
 ```text
-entities: ID → merged entity value
-views: resource + canonical argument → ordered IDs + fetchedAt + cursor metadata
+entities: collection + ID → merged entity value
+views: resource + canonical argument → ordered IDs + fetchedAt + cursor/meta
 ```
 
-An exact view is required. A list entity does not make detail complete, and already loaded entities
-cannot make an unseen filter complete. An unseen argument calls the server.
+An exact view is required. A list entity does not prove detail completeness, and an entity loaded
+for one filter does not make an unseen filter complete. Rows omitted from one filtered response are
+removed only from that view, not globally.
 
-- Fresh local view: restore without a request.
-- Stale local view: restore with `isLoading: false`, set `isFetching: true`, then revalidate.
-- Miss: ordinary first-load query behavior.
-- Revalidation error: retain local data with `isSuccess: true` and `isError: true`.
+For response envelopes such as `{ items, total }`, use `map.split(data) => { rows, meta }` and
+`map.join(rows, meta) => data`.
 
-The visible snapshot can change when background revalidation completes. This is deliberate server
-correction; use `isFetching` for a subtle update indicator. Copy query data into separate draft
-state before binding it to an actively edited form.
+Incoming own fields shallowly merge into canonical entities. Omitted detail-only fields survive a
+later list summary; explicit `null` clears a field. Configure collection `merge` for nested rules and
+`revision` for a comparable server revision such as `updatedAt`.
 
-Remote results update entities and replace only the current view membership. A row omitted from one
-filtered response is not globally deleted.
-
-For response envelopes such as `{ items, total }`, pass `map.split(data) => { rows, meta }` and
-`map.join(rows, meta) => data`. Rows are normalized and cloneable envelope metadata is stored on the
-view.
-
-## Merge and optimistic edits
-
-Incoming own fields shallowly merge into the canonical entity. Omitted detail-only fields survive a
-later summary response; explicit `null` clears a field. Configure collection `merge` for custom
-nested behavior and `revision` for a comparable server version such as `updatedAt`.
-
-Direct query data mutations remain reactive and write through to IndexedDB. Every loaded local
-resource containing the same collection and ID receives the canonical field update. Array removal
-changes only that view, not the global entity.
-
-Always perform the API mutation and refetch views whose membership, ordering, total, or cursor may
+Always call the server mutation and refetch views whose membership, ordering, totals, or cursors may
 have changed. `local()` has no mutation outbox, offline retry, CRDT, or multi-device conflict engine.
 
 ## Version and options
 
-`local.collection({ key, version })` requires an explicit positive integer version. There are no
-migrations: a version bump is a cache miss and old rows for the same collection/scope are removed.
+`local.collection({ key, version })` requires a positive integer version. There are no migrations:
+bumping it makes old views a cache miss and removes older rows for that collection/scope.
 
 Resource options:
 
-- `source` (required): shared collection.
-- `key`: durable view identity override; default model field path.
-- `serializeArg`: collision-safe stable serializer for non-JSON arguments.
-- `map`: `split/join` normalization adapter for response envelopes.
+- `source` (required) — shared collection.
+- `initialData` (required) — value before restore/fetch.
+- `key` — durable resource identity override; defaults to the model field path.
+- `serializeArg` — collision-safe stable serializer for non-JSON arguments.
+- `map` — `split/join` normalization adapter for response envelopes.
 
-Infinite queries persist flattened ID order, cursor, `hasMore`, and cursor history. Realtime queries
-are unsupported in this beta.
+Query internals import no local, IndexedDB, or collection code. The optional adapters attach through
+a generic resource lifecycle. The beta.0 wrapper remains as a deprecated compatibility form:
 
-Use `persist()` for local-owned settings/drafts. Use `local(query())` for server-owned snapshots.
+```ts
+local(query({ initialData: [], queryFn }), { source: products }) // deprecated
+local.query({ source: products, initialData: [], queryFn }) // preferred
+```
+
+Use `persist()` for local-owned preferences, drafts, and UI values. Use `local()` for server-shaped,
+ID-keyed snapshots that restore from IndexedDB and may later be initialized or corrected by a
+server source.

--- a/apps/docs/public/llm/local.txt
+++ b/apps/docs/public/llm/local.txt
@@ -199,6 +199,24 @@ removed only from that view, not globally.
 For response envelopes such as `{ items, total }`, use `map.split(data) => { rows, meta }` and
 `map.join(rows, meta) => data`.
 
+## Collection and freshness boundaries
+
+A collection is the canonical identity boundary for an entity type, not a boundary per endpoint.
+List, detail, and enrichment fragments with the same IDs may share one collection. Resource keys and
+arguments own exact membership, ordering, metadata, and freshness.
+
+- Use separate local resources sharing a collection when they must restore or revalidate
+  independently; each resource may use a different `staleTime`.
+- Keep delayed enrichment inside one `local.query()` when it belongs to that view and should use the
+  same freshness policy. The query may return an `AsyncIterable`: early yields update the UI,
+  `isFetching` remains true, and the completed enriched view is committed to IndexedDB.
+- Do not add entity-level fetch timestamps only to schedule enrichment. Prefer view `staleTime`.
+  Missing optional fields may represent row-level loading until the later result arrives.
+
+Use shorter stale windows for personalized data that changes often and longer windows for stable
+public content. Scope personalized collections by user or tenant; public collections can use a
+static public scope.
+
 Incoming own fields shallowly merge into canonical entities. Omitted detail-only fields survive a
 later list summary; explicit `null` clears a field. Configure collection `merge` for nested rules and
 `revision` for a comparable server revision such as `updatedAt`.

--- a/apps/docs/public/llm/local.txt
+++ b/apps/docs/public/llm/local.txt
@@ -10,12 +10,12 @@ local.infinite()  IndexedDB restore + infinite query revalidation
 ```
 
 All forms keep the ordinary resource state fields (`data`, `isLoading`, `isFetching`, `isSuccess`,
-`isError`, `error`) and share canonical entity values by ID.
+`isError`, `error`) and share canonical entity values by collection identity.
 
 ## Collection and model
 
-Create one collection for each entity type. Entity IDs are detected automatically and may be
-strings or numbers.
+Create one collection for each entity type. A string or finite-number `id` is used by default.
+Supply `getId` when the API uses another identity field.
 
 ```ts
 import { local, model } from '@comwit/state'
@@ -35,6 +35,12 @@ const products = local.collection<ProductEntity>({
   key: 'products',
   version: 1,
   revision: (product) => product.updatedAt,
+})
+
+const externalProducts = local.collection<{ uuid: string; title: string }>({
+  key: 'external-products',
+  version: 1,
+  getId: (product) => product.uuid,
 })
 
 type ProductState = {
@@ -151,7 +157,9 @@ actively edited forms into separate draft state.
 
 Remount the provider when the user/tenant scope changes. Defaults are database
 `'@comwit/state'` and scope `'default'`. IndexedDB failure leaves standalone state in memory and
-makes query adapters behave like ordinary queries.
+makes query adapters behave like ordinary queries. Server environments have no IndexedDB, so the
+storage lifecycle is skipped without throwing and `local.query().load()` uses its normal query
+driver.
 
 ## On-demand normalized storage
 
@@ -178,6 +186,10 @@ have changed. `local()` has no mutation outbox, offline retry, CRDT, or multi-de
 
 `local.collection({ key, version })` requires a positive integer version. There are no migrations:
 bumping it makes old views a cache miss and removes older rows for that collection/scope.
+
+Collection options include `getId(entity)`, which defaults to `entity.id` and is required by the
+type when the entity has no `id`. It must return a stable string or finite number for every
+list/detail fragment.
 
 Resource options:
 

--- a/apps/docs/public/llm/local.txt
+++ b/apps/docs/public/llm/local.txt
@@ -1,0 +1,122 @@
+# local() — IndexedDB-backed on-demand queries
+
+`local()` wraps an existing `query()` or `query.infinite()` without changing its public API. It is
+a normalized durable query cache: restore an exact argument from IndexedDB, render it, then use the
+original `queryFn` to revalidate stale data.
+
+## Basic list/detail model
+
+```ts
+import { local, model, query } from '@comwit/state'
+
+interface TodoEntity {
+  readonly id: string
+  title: string
+  status: 'open' | 'done'
+  updatedAt: number
+  description?: string
+}
+
+type TodoListItem = Pick<TodoEntity, 'id' | 'title' | 'status' | 'updatedAt'>
+type TodoDetail = TodoEntity & { description: string }
+
+const todos = local.collection<TodoEntity>({
+  key: 'todos',
+  version: 1,
+})
+
+export const todo = model({
+  list: local(
+    query<TodoListItem[], TodoFilter>({
+      initialData: [],
+      staleTime: 30_000,
+      queryFn: (filter) => api.todo.list(filter),
+    }),
+    { source: todos }
+  ),
+  detail: local(
+    query<TodoDetail | null, string>({
+      initialData: null,
+      queryFn: (id) => api.todo.detail(id),
+    }),
+    { source: todos }
+  ),
+})
+```
+
+One collection represents one entity type. List/detail/infinite resources keep independent view
+keys and freshness while sharing canonical values by `id`.
+
+## Provider
+
+```tsx
+<ComwitProvider
+  key={user.id}
+  defaultOptions={{
+    local: {
+      database: 'my-app',
+      scope: `user:${user.id}`,
+      onError: reportError,
+    },
+  }}
+>
+```
+
+Remount the provider when scope changes. Defaults are `database: '@comwit/state'` and
+`scope: 'default'`. IndexedDB failure degrades to an ordinary query.
+
+## Storage and loading
+
+```text
+entities: ID → merged entity value
+views: resource + canonical argument → ordered IDs + fetchedAt + cursor metadata
+```
+
+An exact view is required. A list entity does not make detail complete, and already loaded entities
+cannot make an unseen filter complete. An unseen argument calls the server.
+
+- Fresh local view: restore without a request.
+- Stale local view: restore with `isLoading: false`, set `isFetching: true`, then revalidate.
+- Miss: ordinary first-load query behavior.
+- Revalidation error: retain local data with `isSuccess: true` and `isError: true`.
+
+The visible snapshot can change when background revalidation completes. This is deliberate server
+correction; use `isFetching` for a subtle update indicator. Copy query data into separate draft
+state before binding it to an actively edited form.
+
+Remote results update entities and replace only the current view membership. A row omitted from one
+filtered response is not globally deleted.
+
+For response envelopes such as `{ items, total }`, pass `map.split(data) => { rows, meta }` and
+`map.join(rows, meta) => data`. Rows are normalized and cloneable envelope metadata is stored on the
+view.
+
+## Merge and optimistic edits
+
+Incoming own fields shallowly merge into the canonical entity. Omitted detail-only fields survive a
+later summary response; explicit `null` clears a field. Configure collection `merge` for custom
+nested behavior and `revision` for a comparable server version such as `updatedAt`.
+
+Direct query data mutations remain reactive and write through to IndexedDB. Every loaded local
+resource containing the same collection and ID receives the canonical field update. Array removal
+changes only that view, not the global entity.
+
+Always perform the API mutation and refetch views whose membership, ordering, total, or cursor may
+have changed. `local()` has no mutation outbox, offline retry, CRDT, or multi-device conflict engine.
+
+## Version and options
+
+`local.collection({ key, version })` requires an explicit positive integer version. There are no
+migrations: a version bump is a cache miss and old rows for the same collection/scope are removed.
+
+Resource options:
+
+- `source` (required): shared collection.
+- `key`: durable view identity override; default model field path.
+- `serializeArg`: collision-safe stable serializer for non-JSON arguments.
+- `map`: `split/join` normalization adapter for response envelopes.
+
+Infinite queries persist flattened ID order, cursor, `hasMore`, and cursor history. Realtime queries
+are unsupported in this beta.
+
+Use `persist()` for local-owned settings/drafts. Use `local(query())` for server-owned snapshots.

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -3,7 +3,8 @@
 > Full API reference for selector `.load()`, imperative query methods, `query.infinite()`, `query.realtime()`, Suspense, caching, and resource state.
 
 For IndexedDB-backed normalized list/detail/infinite views, see
-https://library.comwit.io/llm/local.txt. Wrapping with `local()` preserves every query method below.
+https://library.comwit.io/llm/local.txt. `local.query()` and `local.infinite()` preserve every
+corresponding query method below; standalone `local()` has no network driver.
 
 ## query(opts)
 
@@ -258,7 +259,7 @@ Re-fetches using the last argument. No-op if `.query()` has never been called.
 await this.model.posts.refetch()
 ```
 
-### .set(data)
+### .set(data, options?)
 
 Manually set resource data without fetching. Marks the resource as successful.
 
@@ -268,7 +269,13 @@ this.model.posts.set([newPost, ...this.model.posts.data])
 
 // Set data + state overrides
 this.model.posts.set({ data: [], isSuccess: true })
+
+// Initialize an exact local/server-owned detail view
+this.model.detail.set(product, { arg: { id: product.id } })
 ```
+
+The optional `arg` establishes the exact resource identity. It is primarily useful when a server
+initializer sets a standalone local resource before a fallback has activated that route key.
 
 ### .nextFetch(arg?)
 
@@ -413,6 +420,9 @@ if (posts.isError) return <p>Error: {posts.error}</p>
 
 ## Server Suspense fallback guidance
 
-For App Router streaming, a fallback does not have to be skeleton-only. Passively read the currently active query state: render cached content when `isSuccess`, otherwise render a skeleton. The resolved server branch can initialize the query through an action that runs `silent(() => resource.set(serverData))`. This uses the existing state API; no separate `hydrate()` primitive is needed.
-
-Only reuse the active cached value when it is valid for the route/identity being rendered. Otherwise use a neutral fallback.
+For App Router streaming with server-owned detail fetching, prefer a standalone `local()` resource.
+The fallback calls `restore(routeArg)`, which checks only the exact IndexedDB view and never starts
+an API request or suspends. The resolved server branch initializes it with
+`silent(() => resource.set(serverData, { arg: routeArg }))`. See the local reference for the full
+pattern. Ordinary query fields may still be read passively, but their active value must already be
+known to match the current route.

--- a/apps/docs/public/llm/query.txt
+++ b/apps/docs/public/llm/query.txt
@@ -2,6 +2,9 @@
 
 > Full API reference for selector `.load()`, imperative query methods, `query.infinite()`, `query.realtime()`, Suspense, caching, and resource state.
 
+For IndexedDB-backed normalized list/detail/infinite views, see
+https://library.comwit.io/llm/local.txt. Wrapping with `local()` preserves every query method below.
+
 ## query(opts)
 
 Creates a single resource descriptor for client-side data fetching. Used inside `model()`.
@@ -196,7 +199,7 @@ function PostList() {
 }
 
 // Wrap with Suspense boundary
-<Suspense fallback={<Skeleton />}>
+;<Suspense fallback={<Skeleton />}>
   <PostList />
 </Suspense>
 ```

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -54,21 +54,22 @@ Rules:
 
 ## types.ts
 
-Use `Query<Data, Arg>` for remotely loaded fields and ordinary types for local/server-initialized state.
+Use `Query<Data, Arg>` for remotely loaded fields and `Local<Data, Arg>` for IndexedDB-backed
+resources that an action or server component initializes.
 
 ```ts
-import type { Query } from '@comwit/state'
+import type { Local, Query } from '@comwit/state'
 
 export type ProductState = {
   products: Query<Pageable<Product>, { page: number; filter: ProductFilter }>
   stats: Query<ProductStats>
-  detail: Query<Product | null, { id: string }>
+  detail: Local<Product | null, { id: string }>
   selectedIds: string[]
   isEditMode: boolean
 }
 
 export type ProductActions = {
-  initDetail(product: Product): void
+  initDetail(id: string, product: Product): void
   refreshAll(): Promise<void>
   loadMore(): Promise<void>
   create(title: string): Promise<void>
@@ -89,16 +90,19 @@ Query type variants:
 The model defines data shape and fetch policy, not UI effects.
 
 ```ts
-import { keepPreviousData, model, query } from '@comwit/state'
+import { keepPreviousData, local, model, query } from '@comwit/state'
+
+const productEntities = local.collection<Product>({ key: 'products', version: 1 })
 
 export const product = model<ProductState>({
-  products: query({
+  products: local.query({
+    source: productEntities,
     initialData: EMPTY_PAGE,
     queryFn: ({ page, filter }) => api.product.list({ page, filter }),
     placeholderData: keepPreviousData,
   }),
   stats: query({ initialData: EMPTY_STATS, queryFn: () => api.product.stats() }),
-  detail: query({ initialData: null, queryFn: ({ id }) => api.product.get(id) }),
+  detail: local({ source: productEntities, initialData: null }),
   selectedIds: [],
   isEditMode: false,
 })
@@ -127,30 +131,27 @@ posts: query.infinite<Post[]>({
 - Model option `rules`: field validators; read `{ errors, isValid }` from `$validation`.
 - Model option `history: true | { limit }`: read `$history.undo()`, `redo()`, `canUndo`, `canRedo`, `ignore(fn)` through the existing domain hook. One action call is one history transaction.
 - `persist({ key, defaultValue, storage? })`: local/session/custom storage, SSR-safe, debounced, cross-tab for localStorage.
-- `local(query(...), { source })`: IndexedDB-backed exact-argument views over normalized entities; stale data revalidates with the original queryFn.
+- `local({ source, initialData })`: standalone exact-argument IndexedDB resource; `.restore()` never calls an API.
+- `local.query({ source, initialData, queryFn })` / `local.infinite(...)`: local-first adapters that revalidate with the existing query lifecycle.
 
 ### Durable on-demand query data
 
-Use one collection per entity type and share it across list/detail/infinite resources:
+Use one collection per entity type and share it across list/detail/infinite resources. A standalone
+detail is useful when a Next.js server component owns its API request:
 
 ```ts
 const products = local.collection<ProductEntity>({ key: 'products', version: 1 })
 
 const product = model({
-  list: local(
-    query<ProductListItem[], Filter>({
-      initialData: [],
-      queryFn: api.product.list,
-    }),
-    { source: products }
-  ),
-  detail: local(
-    query<ProductDetail | null, string>({
-      initialData: null,
-      queryFn: api.product.detail,
-    }),
-    { source: products }
-  ),
+  list: local.query<ProductListItem[], Filter>({
+    source: products,
+    initialData: [],
+    queryFn: api.product.list,
+  }),
+  detail: local<ProductDetail | null, { id: string }>({
+    source: products,
+    initialData: null,
+  }),
 })
 ```
 
@@ -160,9 +161,11 @@ stale views render while `isFetching` and revalidate in the background; unseen a
 List presence never proves detail completeness.
 
 Incoming fields shallowly merge, so a later list summary does not erase omitted detail fields.
-Direct entity edits write through and fan out to loaded views sharing the ID. Refetch after API
-mutations to correct membership/order/totals. Array removal changes one view, not the global entity.
-Use resource `map.split/join` for envelopes such as `{ items, total }`.
+Direct entity edits write through and fan out to loaded views sharing the ID. Standalone `.restore(arg)`
+checks only the exact local view and never fetches; `.set(data, { arg })` writes that exact view;
+`.remove(arg)` resets it to `initialData`. Refetch query-backed views after API mutations to correct
+membership/order/totals. Array removal changes one view, not the global entity. Use resource
+`map.split/join` for envelopes such as `{ items, total }`.
 
 `version` is required and has no migration path: bumping it invalidates and removes older rows.
 Scope by user/tenant and remount `ComwitProvider` when scope changes. This feature is not a full local
@@ -175,6 +178,7 @@ A selector can start a request or passively read data that was already loaded or
 ```tsx
 const products = useProduct((s) => s.products.load({ page, filter })) // start/load this key
 const stats = useProduct((s) => s.stats) // read current state; never starts a request
+const detail = useProduct((s) => s.detail.restore({ id })) // exact IndexedDB only; no API
 ```
 
 Use selector `.load(arg?)` when the view owns the initial request. Its argument is inferred from `Query<Data, Arg>`, and it returns the ordinary query resource state. Use passive selection when another action or server initialization owns loading. Do not create another query hook.
@@ -210,7 +214,7 @@ Action methods from `state(model)`:
 
 - `.query(arg?, options?)` — fetch; honors cache freshness.
 - `.refetch()` — force the active/last argument; no-op before a successful initial query.
-- `.set(data | statePatch)` — set data and mark success; useful for optimistic and server initialization.
+- `.set(data | statePatch, { arg }?)` — set data and mark success; `arg` identifies an exact local/server-initialized view.
 - Infinite: `.nextFetch(arg?)`, `.previousFetch(arg?, options?)`.
 - Realtime: `.unsubscribe()`.
 
@@ -252,22 +256,34 @@ Plain state is mutable inside actions: assign fields, `push`/`splice` arrays, or
 No separate `hydrate()` API is needed. Initialize during client render through an action that wraps writes in `silent()`; do not delay it to an effect.
 
 ```ts
-initDetail(value: Product) {
-  silent(() => this.m.detail.set(value))
+initDetail(id: string, value: Product) {
+  silent(() => this.m.detail.set(value, { arg: { id } }))
 }
 ```
 
-`.set()` marks the query successful, so client fallbacks can distinguish initialized cache from `initialData`.
+`.set()` marks the resource successful. On a standalone local resource, it also stores the exact
+argument view and canonical entity in IndexedDB. `silent()` suppresses notifications, not storage.
 
 ```tsx
-function DetailInit({ value }: { value: Product }) {
+function DetailInit({ id, value }: { id: string; value: Product }) {
   const init = useProduct((s) => s.actions.initDetail)
-  init(value)
+  init(id, value)
   return <ProductView product={value} />
 }
 ```
 
-For a server `<Suspense>` boundary, the client fallback may passively read the current query: show cached content when `isSuccess`, otherwise show a skeleton. The resolved server branch renders `DetailInit`. Reuse cached content only when its active identity is valid for the route; otherwise keep the fallback neutral.
+For a server `<Suspense>` boundary, the client fallback restores only the exact route view. It does
+not call an API or suspend; show cached content when present and otherwise show a skeleton. The
+resolved server branch renders `DetailInit`.
+
+```tsx
+function DetailFallback({ id }: { id: string }) {
+  const detail = useProduct((s) => s.detail.restore({ id }))
+  return detail.data ? <ProductView product={detail.data} /> : <ProductSkeleton />
+}
+```
+
+If the IndexedDB read is still pending when the server initializer runs, the server value wins.
 
 Library `suspense: true` is available for client query suspension: initial query promises suspend, refetches use `isFetching`, and errors go to the nearest error boundary. Prefer the server-streaming pattern above for App Router server work.
 
@@ -366,7 +382,7 @@ Here `@LoginRequired` guards every method, while `@ConfirmDelete` applies only t
 - View-owned query uses selector `.load(arg)`; passive query intentionally omits it.
 - Command/coordinated query stays in an action.
 - Loading, error, empty, and background-fetch behavior are deliberate.
-- Server init uses `silent()` and query `.set()` where applicable.
+- Server init uses `silent()` and `.set(data, { arg })`; a local fallback uses exact `.restore(arg)`.
 - CRUD keeps list/detail/stats consistent and rolls back failed optimistic writes.
 - Proxy values are snapshotted at serialization boundaries.
 - Decorator support is enabled in TypeScript/Next.js.

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -136,21 +136,60 @@ posts: query.infinite<Post[]>({
 
 ### Durable on-demand query data
 
-Use `local` when server-shaped, ID-keyed data should appear immediately from IndexedDB and then be
-corrected by the server. It is especially useful for repeated list/detail navigation, optimistic
-field edits that should fan out across loaded views, and Next.js server-owned details whose Suspense
-fallback may show an exact cached value without starting another request.
+```ts
+// Public content can be shared and kept fresh for longer.
+const posts = local.collection<Post>({
+  key: 'posts',
+  version: 1,
+  scope: 'public',
+})
 
-Model one collection per canonical entity type. It uses `id` by default, supports a custom `getId`,
-and may use a static public scope or a lazy user/tenant scope. Model one resource per independently
-restorable view and freshness policy: filters, list ordering, detail completeness, and cursors remain
-view-specific. Delayed fields that belong to the same view can be emitted progressively from one
-query; split them into another resource only when they need independent restoration or freshness.
+// Personalized rows resolve their user only when the resource is used.
+const projects = local.collection<Project>({
+  key: 'projects',
+  version: 1,
+  scope: ({ state }) => {
+    const userId = state(member).me?.id
+    return userId ? `user:${userId}` : null
+  },
+})
 
-Prefer shorter stale windows for personalized data and longer windows for stable public content.
-Use `persist()` instead for local-owned preferences or drafts, and ordinary `query()` when durable
-restoration has little value. `local` is not an offline mutation queue, CRDT, or multi-device conflict
-engine. Collection versions invalidate old rows rather than migrate them. See
+// Render the list first, then merge delayed fields into the same Project entities.
+async function* loadProjects(filter: ProjectFilter) {
+  const rows = await api.project.list(filter)
+  yield { data: rows, isLoading: false, isSuccess: true }
+
+  const statuses = await api.project.deploymentStatuses(rows.map((row) => row.id))
+  yield {
+    data: mergeDeploymentStatuses(rows, statuses),
+    isLoading: false,
+    isSuccess: true,
+  }
+}
+
+export const app = model({
+  posts: local.query<Post[]>({
+    source: posts,
+    initialData: [],
+    staleTime: 7 * 24 * 60 * 60_000,
+    queryFn: () => api.post.list(),
+  }),
+  projects: local.query<Project[], ProjectFilter>({
+    source: projects,
+    initialData: [],
+    staleTime: 5 * 60_000,
+    queryFn: loadProjects,
+  }),
+  // The server fetches this SEO detail; the client fallback only calls restore({ id }).
+  projectDetail: local<Project | null, { id: string }>({
+    source: projects,
+    initialData: null,
+  }),
+})
+```
+
+Use `persist()` for local-owned preferences and drafts. `local` restores server snapshots; it does
+not queue offline mutations or resolve multi-device conflicts. See
 https://library.comwit.io/llm/local.txt for the full contract and options.
 
 ## Reading and starting queries

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -136,40 +136,22 @@ posts: query.infinite<Post[]>({
 
 ### Durable on-demand query data
 
-Use one collection per entity type and share it across list/detail/infinite resources. A standalone
-detail is useful when a Next.js server component owns its API request:
+Use `local` when server-shaped, ID-keyed data should appear immediately from IndexedDB and then be
+corrected by the server. It is especially useful for repeated list/detail navigation, optimistic
+field edits that should fan out across loaded views, and Next.js server-owned details whose Suspense
+fallback may show an exact cached value without starting another request.
 
-```ts
-const products = local.collection<ProductEntity>({ key: 'products', version: 1 })
+Model one collection per canonical entity type. It uses `id` by default, supports a custom `getId`,
+and may use a static public scope or a lazy user/tenant scope. Model one resource per independently
+restorable view and freshness policy: filters, list ordering, detail completeness, and cursors remain
+view-specific. Delayed fields that belong to the same view can be emitted progressively from one
+query; split them into another resource only when they need independent restoration or freshness.
 
-const product = model({
-  list: local.query<ProductListItem[], Filter>({
-    source: products,
-    initialData: [],
-    queryFn: api.product.list,
-  }),
-  detail: local<ProductDetail | null, { id: string }>({
-    source: products,
-    initialData: null,
-  }),
-})
-```
-
-`entities` stores merged ID-keyed values; `views` stores each resource/argument's ordered IDs,
-freshness, and cursor metadata. Exact cached arguments hydrate first. Fresh views skip the request;
-stale views render while `isFetching` and revalidate in the background; unseen arguments fetch.
-List presence never proves detail completeness.
-
-Incoming fields shallowly merge, so a later list summary does not erase omitted detail fields.
-Direct entity edits write through and fan out to loaded views sharing the ID. Standalone `.restore(arg)`
-checks only the exact local view and never fetches; `.set(data, { arg })` writes that exact view;
-`.remove(arg)` resets it to `initialData`. Refetch query-backed views after API mutations to correct
-membership/order/totals. Array removal changes one view, not the global entity. Use resource
-`map.split/join` for envelopes such as `{ items, total }`.
-
-`version` is required and has no migration path: bumping it invalidates and removes older rows.
-Scope by user/tenant and remount `ComwitProvider` when scope changes. This feature is not a full local
-database or mutation outbox. See https://library.comwit.io/llm/local.txt for the complete contract.
+Prefer shorter stale windows for personalized data and longer windows for stable public content.
+Use `persist()` instead for local-owned preferences or drafts, and ordinary `query()` when durable
+restoration has little value. `local` is not an offline mutation queue, CRDT, or multi-device conflict
+engine. Collection versions invalidate old rows rather than migrate them. See
+https://library.comwit.io/llm/local.txt for the full contract and options.
 
 ## Reading and starting queries
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -17,6 +17,7 @@ Enable `experimentalDecorators` in `tsconfig.json` when using decorators. Wrap t
   context={{ router }}
   defaultOptions={{
     query: { staleTime: 30_000, gcTime: 5 * 60_000 },
+    local: { database: 'my-app', scope: `user:${user.id}` },
     persist: { debounceMs: 100 },
   }}
 >
@@ -126,6 +127,46 @@ posts: query.infinite<Post[]>({
 - Model option `rules`: field validators; read `{ errors, isValid }` from `$validation`.
 - Model option `history: true | { limit }`: read `$history.undo()`, `redo()`, `canUndo`, `canRedo`, `ignore(fn)` through the existing domain hook. One action call is one history transaction.
 - `persist({ key, defaultValue, storage? })`: local/session/custom storage, SSR-safe, debounced, cross-tab for localStorage.
+- `local(query(...), { source })`: IndexedDB-backed exact-argument views over normalized entities; stale data revalidates with the original queryFn.
+
+### Durable on-demand query data
+
+Use one collection per entity type and share it across list/detail/infinite resources:
+
+```ts
+const products = local.collection<ProductEntity>({ key: 'products', version: 1 })
+
+const product = model({
+  list: local(
+    query<ProductListItem[], Filter>({
+      initialData: [],
+      queryFn: api.product.list,
+    }),
+    { source: products }
+  ),
+  detail: local(
+    query<ProductDetail | null, string>({
+      initialData: null,
+      queryFn: api.product.detail,
+    }),
+    { source: products }
+  ),
+})
+```
+
+`entities` stores merged ID-keyed values; `views` stores each resource/argument's ordered IDs,
+freshness, and cursor metadata. Exact cached arguments hydrate first. Fresh views skip the request;
+stale views render while `isFetching` and revalidate in the background; unseen arguments fetch.
+List presence never proves detail completeness.
+
+Incoming fields shallowly merge, so a later list summary does not erase omitted detail fields.
+Direct entity edits write through and fan out to loaded views sharing the ID. Refetch after API
+mutations to correct membership/order/totals. Array removal changes one view, not the global entity.
+Use resource `map.split/join` for envelopes such as `{ items, total }`.
+
+`version` is required and has no migration path: bumping it invalidates and removes older rows.
+Scope by user/tenant and remount `ComwitProvider` when scope changes. This feature is not a full local
+database or mutation outbox. See https://library.comwit.io/llm/local.txt for the complete contract.
 
 ## Reading and starting queries
 

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0-beta.1",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "2.2.0-beta.0"
+    "@comwit/state": "2.2.0-beta.1"
   }
 }

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "type": "module",
   "description": "Deprecated: renamed to @comwit/state. This package re-exports @comwit/state for backward compatibility.",
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "2.2.0-beta.3"
+    "@comwit/state": "^2.2.0"
   }
 }

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "2.2.0-beta.1"
+    "@comwit/state": "2.2.0-beta.2"
   }
 }

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.1.0",
+  "version": "2.2.0-beta.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "type": "module",
   "description": "Deprecated: renamed to @comwit/state. This package re-exports @comwit/state for backward compatibility.",
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "^2.1.0"
+    "@comwit/state": "2.2.0-beta.0"
   }
 }

--- a/packages/comwit-compat/package.json
+++ b/packages/comwit-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comwit",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0-beta.3",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -49,6 +49,6 @@
     "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@comwit/state": "2.2.0-beta.2"
+    "@comwit/state": "2.2.0-beta.3"
   }
 }

--- a/packages/comwit/README.md
+++ b/packages/comwit/README.md
@@ -28,18 +28,20 @@ Pass the URL to Claude Code. It handles the rest.
 const todos = local.collection<Todo>({ key: 'todos', version: 1 })
 
 const todo = model({
-  list: local(
-    query<Todo[], TodoFilter>({
-      initialData: [],
-      queryFn: api.todo.list,
-    }),
-    { source: todos }
-  ),
+  list: local.query<Todo[], TodoFilter>({
+    source: todos,
+    initialData: [],
+    queryFn: api.todo.list,
+  }),
+  detail: local<Todo | null, { id: string }>({
+    source: todos,
+    initialData: null,
+  }),
 })
 ```
 
-`local(query(...))` restores exact argument views from normalized IndexedDB entities and uses the
-original `queryFn` to revalidate stale data. The `.load()`, `.query()`, `.refetch()`, `.set()`, and
-optimistic mutation interfaces remain unchanged.
+`local()` restores an exact IndexedDB view without making an API request, which fits server-owned
+SEO details. `local.query()` and `local.infinite()` add background server revalidation while keeping
+the existing `.load()`, `.query()`, `.refetch()`, `.set()`, and optimistic mutation interfaces.
 
-[Read the local query reference](https://library.comwit.io/docs/api/local).
+[Read the local resource reference](https://library.comwit.io/docs/api/local).

--- a/packages/comwit/README.md
+++ b/packages/comwit/README.md
@@ -21,3 +21,25 @@ https://library.comwit.io/llms.txt
 ```
 
 Pass the URL to Claude Code. It handles the rest.
+
+## Durable on-demand queries (2.2 beta)
+
+```ts
+const todos = local.collection<Todo>({ key: 'todos', version: 1 })
+
+const todo = model({
+  list: local(
+    query<Todo[], TodoFilter>({
+      initialData: [],
+      queryFn: api.todo.list,
+    }),
+    { source: todos }
+  ),
+})
+```
+
+`local(query(...))` restores exact argument views from normalized IndexedDB entities and uses the
+original `queryFn` to revalidate stale data. The `.load()`, `.query()`, `.refetch()`, `.set()`, and
+optimistic mutation interfaces remain unchanged.
+
+[Read the local query reference](https://library.comwit.io/docs/api/local).

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0-beta.1",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.1.0",
+  "version": "2.2.0-beta.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "type": "module",
   "description": "React state management for vibe coding. Less tokens. Built for Claude Code.",
@@ -65,6 +65,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "fake-indexeddb": "^6.2.4",
     "happy-dom": "^20.6.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0-beta.3",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "type": "module",
   "description": "React state management for vibe coding. Less tokens. Built for Claude Code.",

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -26,6 +26,18 @@ import type { HistoryApi, HistoryOptions, HistoryConfig } from './history'
 
 import { computedPlugin } from './computed'
 import { computed } from './computed'
+import {
+  local,
+  type LocalCollection,
+  type LocalCollectionOptions,
+  type LocalDefaults,
+  type LocalDataMap,
+  type LocalEntity,
+  type LocalEntityFragment,
+  type LocalEntityId,
+  type LocalErrorContext,
+  type LocalResourceOptions,
+} from './local'
 
 // Register built-in plugins
 registerPlugin(queryPlugin)
@@ -66,6 +78,7 @@ export {
   silent,
   ComwitProvider,
   query,
+  local,
   keepPreviousData,
   persist,
   computed,
@@ -90,4 +103,13 @@ export type {
   HistoryApi,
   HistoryOptions,
   HistoryConfig,
+  LocalCollection,
+  LocalCollectionOptions,
+  LocalDefaults,
+  LocalDataMap,
+  LocalEntity,
+  LocalEntityFragment,
+  LocalEntityId,
+  LocalErrorContext,
+  LocalResourceOptions,
 }

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -28,6 +28,8 @@ import { computedPlugin } from './computed'
 import { computed } from './computed'
 import {
   local,
+  type BoundLocalResource,
+  type Local,
   type LocalCollection,
   type LocalCollectionOptions,
   type LocalDefaults,
@@ -36,7 +38,11 @@ import {
   type LocalEntityFragment,
   type LocalEntityId,
   type LocalErrorContext,
+  type LocalInfiniteOptions,
+  type LocalQueryOptions,
   type LocalResourceOptions,
+  type LocalStandaloneOptions,
+  type SelectableLocalResource,
 } from './local'
 
 // Register built-in plugins
@@ -54,10 +60,11 @@ function create<S extends object, A>(
   function useStore<R>(selector: (state: SelectableState & { actions: A }) => R): R
   function useStore<R>(selector?: (state: SelectableState & { actions: A }) => R) {
     const actions = useAction<A>(options.actions)
-    const withActions = (state: SelectableState): SelectableState & { actions: A } => ({
-      ...state,
-      actions,
-    })
+    const withActions = (state: SelectableState): SelectableState & { actions: A } =>
+      ({
+        ...(state as object),
+        actions,
+      }) as SelectableState & { actions: A }
 
     const finalSelector = selector
       ? (state: SelectableState) => selector(withActions(state))
@@ -103,6 +110,8 @@ export type {
   HistoryApi,
   HistoryOptions,
   HistoryConfig,
+  BoundLocalResource,
+  Local,
   LocalCollection,
   LocalCollectionOptions,
   LocalDefaults,
@@ -111,5 +120,9 @@ export type {
   LocalEntityFragment,
   LocalEntityId,
   LocalErrorContext,
+  LocalInfiniteOptions,
+  LocalQueryOptions,
   LocalResourceOptions,
+  LocalStandaloneOptions,
+  SelectableLocalResource,
 }

--- a/packages/comwit/src/core/index.ts
+++ b/packages/comwit/src/core/index.ts
@@ -41,6 +41,9 @@ import {
   type LocalInfiniteOptions,
   type LocalQueryOptions,
   type LocalResourceOptions,
+  type LocalScope,
+  type LocalScopeContext,
+  type LocalScopeResolver,
   type LocalStandaloneOptions,
   type SelectableLocalResource,
 } from './local'
@@ -123,6 +126,9 @@ export type {
   LocalInfiniteOptions,
   LocalQueryOptions,
   LocalResourceOptions,
+  LocalScope,
+  LocalScopeContext,
+  LocalScopeResolver,
   LocalStandaloneOptions,
   SelectableLocalResource,
 }

--- a/packages/comwit/src/core/local.ts
+++ b/packages/comwit/src/core/local.ts
@@ -30,11 +30,14 @@ const DEFAULT_DATABASE = '@comwit/state'
 const DEFAULT_SCOPE = 'default'
 
 export type LocalEntityId = string | number
-export type LocalEntity = { id: LocalEntityId } & Record<string, unknown>
-export type LocalEntityFragment<TEntity extends LocalEntity> = Pick<TEntity, 'id'> &
-  Partial<Omit<TEntity, 'id'>>
+export type LocalEntity = object
+export type LocalEntityFragment<TEntity extends LocalEntity> = TEntity extends {
+  id: LocalEntityId
+}
+  ? Pick<TEntity, 'id'> & Partial<Omit<TEntity, 'id'>>
+  : Partial<TEntity>
 
-export type LocalCollectionOptions<TEntity extends LocalEntity> = {
+type LocalCollectionBaseOptions<TEntity extends LocalEntity> = {
   /** Stable persisted namespace for this entity type. */
   key: string
   /** App-managed schema version. Changing it invalidates and removes older rows. */
@@ -48,8 +51,24 @@ export type LocalCollectionOptions<TEntity extends LocalEntity> = {
   revision?: (entity: Readonly<Partial<TEntity>>) => string | number | undefined
 }
 
+type LocalCollectionIdentityOptions<TEntity extends LocalEntity> = TEntity extends {
+  id: LocalEntityId
+}
+  ? {
+      /** Entity identity extractor. Defaults to `entity.id`. */
+      getId?: (entity: Readonly<TEntity>) => LocalEntityId
+    }
+  : {
+      /** Entity identity extractor. Required when the entity has no string/number `id`. */
+      getId: (entity: Readonly<TEntity>) => LocalEntityId
+    }
+
+export type LocalCollectionOptions<TEntity extends LocalEntity> =
+  LocalCollectionBaseOptions<TEntity> & LocalCollectionIdentityOptions<TEntity>
+
 export type LocalCollection<TEntity extends LocalEntity> = Readonly<
   LocalCollectionOptions<TEntity> & {
+    getId: (entity: Readonly<TEntity>) => LocalEntityId
     [LOCAL_COLLECTION_BRAND]: true
   }
 >
@@ -207,10 +226,15 @@ function createCollection<TEntity extends LocalEntity>(
     throw new Error('local.collection() requires version to be a positive integer')
   }
 
+  const getId =
+    options.getId ??
+    ((entity: Readonly<TEntity>) => (entity as { id?: unknown }).id as LocalEntityId)
+
   return Object.freeze({
     ...options,
+    getId,
     [LOCAL_COLLECTION_BRAND]: true as const,
-  })
+  }) as LocalCollection<TEntity>
 }
 
 function attachLocal<
@@ -389,7 +413,7 @@ type NormalizedState = {
   dataKind: DataKind
   dataMeta?: unknown
   ids: LocalEntityId[]
-  entities: LocalEntity[]
+  entities: Array<{ id: LocalEntityId; value: LocalEntity }>
   state: Record<string, unknown>
 }
 
@@ -609,41 +633,58 @@ function viewStorageKey(
 }
 
 function isEntity(value: unknown): value is LocalEntity {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
-  const id = (value as { id?: unknown }).id
-  return typeof id === 'string' || (typeof id === 'number' && Number.isFinite(id))
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function entityId(
+  collection: LocalCollection<LocalEntity>,
+  value: unknown
+): LocalEntityId | undefined {
+  if (!isEntity(value)) return undefined
+  const id = collection.getId(value)
+  if (typeof id === 'string') return id
+  if (typeof id === 'number' && Number.isFinite(id)) return id
+  return undefined
 }
 
 function normalizeState(state: ResourceDataLike, metadata: LocalResourceMetadata): NormalizedState {
   const plain = snapshot(state) as ResourceDataLike
   const data = plain.data
   let dataKind: DataKind
-  let entities: LocalEntity[]
+  let values: LocalEntity[]
   let dataMeta: unknown
 
   if (metadata.map) {
     const mapped = metadata.map.split(data)
     if (!mapped || !Array.isArray(mapped.rows) || !mapped.rows.every(isEntity)) {
-      throw new Error('local() map.split() must return entity rows with string or number ids')
+      throw new Error('local() map.split() must return entity object rows')
     }
     dataKind = 'mapped'
-    entities = mapped.rows as LocalEntity[]
+    values = mapped.rows as LocalEntity[]
     dataMeta = mapped.meta
   } else if (data === null) {
     dataKind = 'null'
-    entities = []
+    values = []
   } else if (Array.isArray(data)) {
     if (!data.every(isEntity)) {
-      throw new Error('local() array data must contain objects with a string or number id')
+      throw new Error('local() array data must contain entity objects')
     }
     dataKind = 'array'
-    entities = data as LocalEntity[]
+    values = data as LocalEntity[]
   } else if (isEntity(data)) {
     dataKind = 'entity'
-    entities = [data]
+    values = [data]
   } else {
     throw new Error('local() data must be an entity, an entity array, or null')
   }
+
+  const entities = values.map((value) => {
+    const id = entityId(metadata.source, value)
+    if (id === undefined) {
+      throw new Error('local() getId() must return a finite number or string for every entity')
+    }
+    return { id, value }
+  })
 
   const stateMeta: Record<string, unknown> = { ...plain }
   delete stateMeta.data
@@ -704,7 +745,7 @@ function mergeEntity(
   if (compareRevision(collection, current, incoming) < 0) return current
   if (collection.merge) {
     const merged = collection.merge(current, incoming)
-    return { ...merged, id: incoming.id } as LocalEntity
+    return { ...incoming, ...merged } as LocalEntity
   }
   return { ...current, ...incoming }
 }
@@ -718,9 +759,13 @@ function idsFromOp(
   if (!op || op[1][0] !== 'data') return ids
 
   const add = (value: unknown) => {
-    if (isEntity(value)) ids.add(idToken(value.id))
+    const id = entityId(metadata.source, value)
+    if (id !== undefined) ids.add(idToken(id))
     if (Array.isArray(value)) {
-      for (const item of value) if (isEntity(item)) ids.add(idToken(item.id))
+      for (const item of value) {
+        const itemId = entityId(metadata.source, item)
+        if (itemId !== undefined) ids.add(idToken(itemId))
+      }
     }
   }
 
@@ -999,8 +1044,8 @@ class LocalManager {
     const records: EntityRecord[] = []
     const changedEntityKeys = new Set<string>()
 
-    for (const entity of incoming.entities) {
-      const token = idToken(entity.id)
+    for (const { id, value: entity } of incoming.entities) {
+      const token = idToken(id)
       const current = existing.get(token)
       const protectLocal =
         !local &&
@@ -1013,11 +1058,11 @@ class LocalManager {
       const nextLocalRevision =
         local && input.dirtyIds.has(token) ? localRevision : (current?.localRevision ?? 0)
       const record: EntityRecord = {
-        key: entityStorageKey(this.scope, collection.key, collection.version, entity.id),
+        key: entityStorageKey(this.scope, collection.key, collection.version, id),
         scope: this.scope,
         collection: collection.key,
         version: collection.version,
-        id: entity.id,
+        id,
         value: nextValue,
         updatedAt: Date.now(),
         localRevision: nextLocalRevision,
@@ -1180,18 +1225,21 @@ export class LocalResourceBinding {
         const plain = snapshot(this.state) as ResourceDataLike
         const mapped = this.metadata.map.split(plain.data)
         const rows = mapped.rows.map((item) => {
-          const next = byId.get(idToken(item.id))
+          const id = entityId(this.metadata.source, item)
+          const next = id === undefined ? undefined : byId.get(idToken(id))
           return (next ?? item) as LocalEntity
         })
         this.state.data = this.metadata.map.join(rows, mapped.meta)
       } else if (Array.isArray(data)) {
         for (const item of data) {
-          if (!isEntity(item)) continue
-          const next = byId.get(idToken(item.id))
+          const id = entityId(this.metadata.source, item)
+          if (id === undefined) continue
+          const next = byId.get(idToken(id))
           if (next) Object.assign(item, next)
         }
       } else if (isEntity(data)) {
-        const next = byId.get(idToken(data.id))
+        const id = entityId(this.metadata.source, data)
+        const next = id === undefined ? undefined : byId.get(idToken(id))
         if (next) Object.assign(data, next)
       }
     })

--- a/packages/comwit/src/core/local.ts
+++ b/packages/comwit/src/core/local.ts
@@ -1,4 +1,5 @@
 import { snapshot, subscribeOps, type ProxyOp } from './proxy'
+import type { Model } from './model'
 import { query } from './query/descriptor'
 import {
   RESOURCE_LIFECYCLE,
@@ -9,9 +10,11 @@ import type {
   AnyResourceDescriptor,
   InfiniteResourceBuilderOptions,
   InfiniteResourceDescriptor,
+  QueryBindingRegistry,
   QueryCacheEntry,
   QueryCacheKey,
   ResourceBaseState,
+  BoundResourceState,
   ResourceDataLike,
   ResourceSetOptions,
   ResourceRuntimeState,
@@ -37,11 +40,26 @@ export type LocalEntityFragment<TEntity extends LocalEntity> = TEntity extends {
   ? Pick<TEntity, 'id'> & Partial<Omit<TEntity, 'id'>>
   : Partial<TEntity>
 
+export type LocalScopeContext = {
+  /** Resolve another model lazily from the current provider registry. */
+  state<T extends object>(model: Model<T>): BoundResourceState<T>
+}
+
+export type LocalScopeResolver = (context: LocalScopeContext) => string | null | undefined
+
+export type LocalScope = string | LocalScopeResolver
+
 type LocalCollectionBaseOptions<TEntity extends LocalEntity> = {
   /** Stable persisted namespace for this entity type. */
   key: string
   /** App-managed schema version. Changing it invalidates and removes older rows. */
   version: number
+  /**
+   * Optional persisted boundary for this collection. A resolver is evaluated lazily
+   * when the resource is used, so it may read another provider-bound model.
+   * Returning null/undefined skips IndexedDB for that operation.
+   */
+  scope?: LocalScope
   /** Advanced merge hook. The default shallowly merges fields present in the response. */
   merge?: (
     current: Readonly<Partial<TEntity>>,
@@ -116,7 +134,7 @@ export type LocalResourceOptions<
 }
 
 export type LocalErrorContext = {
-  operation: 'open' | 'read' | 'write' | 'cleanup' | 'normalize'
+  operation: 'open' | 'read' | 'write' | 'cleanup' | 'normalize' | 'scope'
   collection?: string
   resource?: string
 }
@@ -224,6 +242,9 @@ function createCollection<TEntity extends LocalEntity>(
   }
   if (!Number.isInteger(options.version) || options.version < 1) {
     throw new Error('local.collection() requires version to be a positive integer')
+  }
+  if (typeof options.scope === 'string' && !options.scope.trim()) {
+    throw new Error('local.collection() scope must be non-empty when provided')
   }
 
   const getId =
@@ -426,6 +447,7 @@ export type LocalHydratedView = {
 
 type ReconcileInput = {
   incoming: NormalizedState
+  activeView: ActiveView
   previousView?: ViewRecord
   existing: Map<string, EntityRecord>
   binding: LocalResourceBinding
@@ -806,7 +828,7 @@ export function createLocalRegistryState(defaults?: LocalDefaults): LocalRegistr
 }
 
 class LocalManager {
-  readonly scope: string
+  readonly defaultScope: string
   private readonly database?: LocalDatabase
   private readonly onError?: LocalDefaults['onError']
   private readonly bindings = new Set<LocalResourceBinding>()
@@ -817,7 +839,7 @@ class LocalManager {
   private writeTail: Promise<void> = Promise.resolve()
 
   constructor(defaults: LocalDefaults | undefined, factory: IDBFactory | undefined) {
-    this.scope = defaults?.scope ?? DEFAULT_SCOPE
+    this.defaultScope = defaults?.scope ?? DEFAULT_SCOPE
     this.onError = defaults?.onError
     if (factory) {
       this.database = new LocalDatabase(factory, defaults?.database ?? DEFAULT_DATABASE)
@@ -828,36 +850,43 @@ class LocalManager {
     this.bindings.add(binding)
   }
 
-  revision(collection: LocalCollection<LocalEntity>): number {
-    return this.collectionRevisions.get(this.collectionNamespace(collection)) ?? 0
+  revision(scope: string, collection: LocalCollection<LocalEntity>): number {
+    return this.collectionRevisions.get(this.collectionNamespace(scope, collection)) ?? 0
   }
 
-  markLocalMutation(collection: LocalCollection<LocalEntity>): number {
-    const namespace = this.collectionNamespace(collection)
+  markLocalMutation(scope: string, collection: LocalCollection<LocalEntity>): number {
+    const namespace = this.collectionNamespace(scope, collection)
     const revision = (this.collectionRevisions.get(namespace) ?? 0) + 1
     this.collectionRevisions.set(namespace, revision)
     return revision
   }
 
-  private collectionNamespace(collection: LocalCollection<LocalEntity>): string {
-    return JSON.stringify([this.scope, collection.key, collection.version])
+  private collectionNamespace(scope: string, collection: LocalCollection<LocalEntity>): string {
+    return JSON.stringify([scope, collection.key, collection.version])
   }
 
-  private entityCacheKey(collection: LocalCollection<LocalEntity>, id: LocalEntityId): string {
-    return JSON.stringify([this.collectionNamespace(collection), idToken(id)])
+  private entityCacheKey(
+    scope: string,
+    collection: LocalCollection<LocalEntity>,
+    id: LocalEntityId
+  ): string {
+    return JSON.stringify([this.collectionNamespace(scope, collection), idToken(id)])
   }
 
-  private report(error: unknown, context: LocalErrorContext): void {
+  report(error: unknown, context: LocalErrorContext): void {
     this.onError?.(error, context)
   }
 
-  private async ensureVersion(collection: LocalCollection<LocalEntity>): Promise<void> {
+  private async ensureVersion(
+    scope: string,
+    collection: LocalCollection<LocalEntity>
+  ): Promise<void> {
     if (!this.database) return
-    const namespace = this.collectionNamespace(collection)
+    const namespace = this.collectionNamespace(scope, collection)
     if (this.cleanedVersions.has(namespace)) return
     this.cleanedVersions.add(namespace)
     try {
-      await this.database.cleanupOldVersions(this.scope, collection.key, collection.version)
+      await this.database.cleanupOldVersions(scope, collection.key, collection.version)
     } catch (error) {
       this.report(error, { operation: 'cleanup', collection: collection.key })
     }
@@ -873,22 +902,30 @@ class LocalManager {
   }
 
   async hydrate(binding: LocalResourceBinding): Promise<LocalHydratedView | undefined> {
-    if (!this.database || !binding.activeView) return undefined
+    const activeView = binding.activeView
+    if (!this.database || !activeView) return undefined
     await this.writeTail
-    await this.ensureVersion(binding.metadata.source)
+    await this.ensureVersion(activeView.scope, binding.metadata.source)
 
     try {
-      const stored = await this.database.readView(binding.activeView.key)
+      const stored = await this.database.readView(activeView.key)
       if (!stored) return undefined
+      if (!binding.matchesActiveView(activeView)) {
+        binding.refreshScope(true)
+        return undefined
+      }
 
       stored.view.lastAccessedAt = Date.now()
       this.viewCache.set(stored.view.key, stored.view)
       for (const record of stored.entities) {
-        this.entityCache.set(this.entityCacheKey(binding.metadata.source, record.id), record)
-        const currentRevision = this.revision(binding.metadata.source)
+        this.entityCache.set(
+          this.entityCacheKey(activeView.scope, binding.metadata.source, record.id),
+          record
+        )
+        const currentRevision = this.revision(activeView.scope, binding.metadata.source)
         if (record.localRevision > currentRevision) {
           this.collectionRevisions.set(
-            this.collectionNamespace(binding.metadata.source),
+            this.collectionNamespace(activeView.scope, binding.metadata.source),
             record.localRevision
           )
         }
@@ -946,7 +983,8 @@ class LocalManager {
     requestStartRevision?: number,
     mutationRevision?: number
   ): Promise<void> {
-    if (!binding.activeView) return
+    const activeView = binding.activeView
+    if (!activeView) return
 
     let incoming: NormalizedState
     try {
@@ -966,6 +1004,7 @@ class LocalManager {
     ): ReconcileOutput => {
       const input: ReconcileInput = {
         incoming,
+        activeView,
         previousView,
         existing: existingFromStore,
         binding,
@@ -982,18 +1021,18 @@ class LocalManager {
     let output: ReconcileOutput
     try {
       output = await this.enqueue(async () => {
-        await this.ensureVersion(binding.metadata.source)
+        await this.ensureVersion(activeView.scope, binding.metadata.source)
         if (this.database) {
           return this.database.reconcile(
-            binding.activeView!.key,
-            this.scope,
+            activeView.key,
+            activeView.scope,
             binding.metadata.source.key,
             binding.metadata.source.version,
             incoming.ids,
             reconcile
           )
         }
-        return reconcile(this.viewCache.get(binding.activeView!.key), new Map())
+        return reconcile(this.viewCache.get(activeView.key), new Map())
       })
     } catch (error) {
       this.report(error, {
@@ -1001,21 +1040,27 @@ class LocalManager {
         collection: binding.metadata.source.key,
         resource: binding.resource,
       })
-      output = reconcile(this.viewCache.get(binding.activeView.key), new Map())
+      output = reconcile(this.viewCache.get(activeView.key), new Map())
     }
 
     this.viewCache.set(output.view.key, output.view)
     for (const record of output.entities) {
-      this.entityCache.set(this.entityCacheKey(binding.metadata.source, record.id), record)
+      this.entityCache.set(
+        this.entityCacheKey(activeView.scope, binding.metadata.source, record.id),
+        record
+      )
     }
 
-    if (!local) {
+    const remainsActive = binding.matchesActiveView(activeView)
+    if (!remainsActive) binding.refreshScope(true)
+
+    if (!local && remainsActive) {
       const byId = new Map(output.entities.map((record) => [idToken(record.id), record]))
       const ordered = output.view.ids
         .map(
           (id) =>
             byId.get(idToken(id)) ??
-            this.entityCache.get(this.entityCacheKey(binding.metadata.source, id))
+            this.entityCache.get(this.entityCacheKey(activeView.scope, binding.metadata.source, id))
         )
         .filter((record): record is EntityRecord => record !== undefined)
       if (ordered.length === output.view.ids.length) {
@@ -1026,18 +1071,18 @@ class LocalManager {
     const changed = output.entities.filter((record) =>
       output.changedEntityKeys.has(idToken(record.id))
     )
-    this.fanOut(binding.metadata.source, changed, binding)
+    this.fanOut(activeView.scope, binding.metadata.source, changed, binding)
   }
 
   private reconcile(input: ReconcileInput): ReconcileOutput {
-    const { binding, incoming, previousView, local, requestStartRevision } = input
+    const { activeView, binding, incoming, previousView, local, requestStartRevision } = input
     const collection = binding.metadata.source
-    const namespace = this.collectionNamespace(collection)
+    const namespace = this.collectionNamespace(activeView.scope, collection)
     const localRevision = input.mutationRevision ?? this.collectionRevisions.get(namespace) ?? 0
 
     const existing = new Map(input.existing)
     for (const id of new Set([...incoming.ids, ...(previousView?.ids ?? [])])) {
-      const cached = this.entityCache.get(this.entityCacheKey(collection, id))
+      const cached = this.entityCache.get(this.entityCacheKey(activeView.scope, collection, id))
       if (cached) existing.set(idToken(id), cached)
     }
 
@@ -1058,8 +1103,8 @@ class LocalManager {
       const nextLocalRevision =
         local && input.dirtyIds.has(token) ? localRevision : (current?.localRevision ?? 0)
       const record: EntityRecord = {
-        key: entityStorageKey(this.scope, collection.key, collection.version, id),
-        scope: this.scope,
+        key: entityStorageKey(activeView.scope, collection.key, collection.version, id),
+        scope: activeView.scope,
         collection: collection.key,
         version: collection.version,
         id,
@@ -1090,7 +1135,7 @@ class LocalManager {
     }
 
     const view: ViewRecord = {
-      ...binding.activeView!,
+      ...activeView,
       dataKind: protectLocalView ? previousView.dataKind : incoming.dataKind,
       dataMeta: protectLocalView ? previousView.dataMeta : incoming.dataMeta,
       ids,
@@ -1105,6 +1150,7 @@ class LocalManager {
   }
 
   fanOut(
+    scope: string,
     collection: LocalCollection<LocalEntity>,
     records: EntityRecord[],
     source?: LocalResourceBinding
@@ -1113,6 +1159,7 @@ class LocalManager {
     for (const binding of this.bindings) {
       if (
         binding === source ||
+        binding.activeView?.scope !== scope ||
         binding.metadata.source.key !== collection.key ||
         binding.metadata.source.version !== collection.version
       ) {
@@ -1120,7 +1167,7 @@ class LocalManager {
       }
       binding.applyEntities(records)
     }
-    source?.applyEntities(records)
+    if (source?.activeView?.scope === scope) source.applyEntities(records)
   }
 }
 
@@ -1129,8 +1176,15 @@ type ActiveView = Omit<
   'dataKind' | 'ids' | 'state' | 'fetchedAt' | 'lastAccessedAt' | 'cursorHistory' | 'localRevision'
 >
 
+type LocalRequestToken = {
+  scope?: string
+  revision: number
+}
+
 export class LocalResourceBinding {
   activeView?: ActiveView
+  private activeScope?: string
+  private scopeInitialized = false
   private suppress = 0
   private pendingMutation = false
   private pendingMutationRevision = 0
@@ -1142,7 +1196,8 @@ export class LocalResourceBinding {
     readonly resource: string,
     readonly state: ResourceDataLike,
     readonly runtime: ResourceRuntimeState,
-    readonly descriptor: AnyResourceDescriptor
+    readonly descriptor: AnyResourceDescriptor,
+    private readonly registry: QueryBindingRegistry
   ) {
     manager.register(this)
     subscribeOps(state, (op) => this.onOperation(op))
@@ -1157,19 +1212,59 @@ export class LocalResourceBinding {
     }
   }
 
-  activate(argKey: QueryCacheKey): void {
+  private resolveScope(): string | undefined {
+    const source = this.metadata.source
+    if (source.scope === undefined) return this.manager.defaultScope
+    if (typeof source.scope === 'string') return source.scope
+
+    const getModelState = this.registry.getModelState
+    if (!getModelState) return undefined
+
+    try {
+      const state: LocalScopeContext['state'] = <T extends object>(model: Model<T>) =>
+        getModelState(model) as BoundResourceState<T>
+      const resolved = source.scope({ state })
+      if (resolved == null) return undefined
+      if (typeof resolved === 'string' && resolved.trim()) return resolved
+      throw new Error('local.collection() scope resolver must return a non-empty string or null')
+    } catch (error) {
+      this.manager.report(error, {
+        operation: 'scope',
+        collection: source.key,
+        resource: this.resource,
+      })
+      return undefined
+    }
+  }
+
+  private setScope(scope: string | undefined, resetOnChange: boolean): void {
+    const changed = this.scopeInitialized && this.activeScope !== scope
+    this.scopeInitialized = true
+    this.activeScope = scope
+
+    if (!changed) return
+    this.runtime.fetchId++
+    this.runtime.cacheEntries.clear()
+    if (resetOnChange) {
+      this.runInternal(() =>
+        Object.assign(this.state, structuredClone(this.descriptor.initialState))
+      )
+    }
+  }
+
+  private createActiveView(argKey: QueryCacheKey, scope: string): ActiveView {
     const source = this.metadata.source
     const resource = this.metadata.key ?? this.resource
-    this.activeView = {
+    return {
       key: viewStorageKey(
-        this.manager.scope,
+        scope,
         source.key,
         source.version,
         resource,
         this.descriptor.kind,
         argKey
       ),
-      scope: this.manager.scope,
+      scope,
       collection: source.key,
       version: source.version,
       resource,
@@ -1178,13 +1273,40 @@ export class LocalResourceBinding {
     }
   }
 
+  activate(argKey: QueryCacheKey): void {
+    const scope = this.resolveScope()
+    this.setScope(scope, true)
+    this.activeView = scope ? this.createActiveView(argKey, scope) : undefined
+  }
+
+  matchesActiveView(view: ActiveView): boolean {
+    return (
+      this.resolveScope() === view.scope &&
+      this.activeView?.key === view.key &&
+      this.activeView.scope === view.scope
+    )
+  }
+
+  refreshScope(resetOnChange: boolean): void {
+    const scope = this.resolveScope()
+    this.setScope(scope, resetOnChange)
+    this.activeView =
+      scope && this.runtime.activeKey
+        ? this.createActiveView(this.runtime.activeKey, scope)
+        : undefined
+  }
+
   activeEntry(): QueryCacheEntry | undefined {
     if (!this.runtime.activeKey) return undefined
     return this.runtime.cacheEntries.get(this.runtime.activeKey)
   }
 
-  currentRevision(): number {
-    return this.manager.revision(this.metadata.source)
+  currentRevision(): LocalRequestToken {
+    const scope = this.activeView?.scope
+    return {
+      scope,
+      revision: scope ? this.manager.revision(scope, this.metadata.source) : 0,
+    }
   }
 
   async hydrate(): Promise<LocalHydratedView | undefined> {
@@ -1196,9 +1318,32 @@ export class LocalResourceBinding {
   async commitRemote(
     entry: QueryCacheEntry,
     fetchedAt: number,
-    requestStartRevision: number
+    requestToken: LocalRequestToken
   ): Promise<void> {
-    await this.manager.commitRemote(this, entry, fetchedAt, requestStartRevision)
+    const resolvedScope = this.resolveScope()
+
+    if (requestToken.scope && requestToken.scope !== resolvedScope) {
+      this.setScope(resolvedScope, true)
+      this.activeView =
+        resolvedScope && this.runtime.activeKey
+          ? this.createActiveView(this.runtime.activeKey, resolvedScope)
+          : undefined
+      return
+    }
+
+    if (!requestToken.scope && resolvedScope) {
+      this.setScope(resolvedScope, false)
+      this.activeView = this.runtime.activeKey
+        ? this.createActiveView(this.runtime.activeKey, resolvedScope)
+        : undefined
+      requestToken = {
+        scope: resolvedScope,
+        revision: this.manager.revision(resolvedScope, this.metadata.source),
+      }
+    }
+
+    if (!this.activeView || !requestToken.scope) return
+    await this.manager.commitRemote(this, entry, fetchedAt, requestToken.revision)
   }
 
   syncActiveCache(): void {
@@ -1248,10 +1393,23 @@ export class LocalResourceBinding {
 
   private onOperation(op: ProxyOp | undefined): void {
     if (this.suppress > 0 || !op || op[1][0] !== 'data') return
+    const scope = this.resolveScope()
+    if (!this.scopeInitialized || this.activeScope !== scope) {
+      this.setScope(scope, true)
+      this.activeView =
+        scope && this.runtime.activeKey
+          ? this.createActiveView(this.runtime.activeKey, scope)
+          : undefined
+      return
+    }
+    if (!this.activeView) return
     for (const id of idsFromOp(op, this.state, this.metadata)) this.dirtyIds.add(id)
     if (this.pendingMutation) return
     this.pendingMutation = true
-    this.pendingMutationRevision = this.manager.markLocalMutation(this.metadata.source)
+    this.pendingMutationRevision = this.manager.markLocalMutation(
+      this.activeView.scope,
+      this.metadata.source
+    )
 
     queueMicrotask(() => {
       this.pendingMutation = false
@@ -1265,28 +1423,30 @@ export class LocalResourceBinding {
 }
 
 export function bindLocalResource(
-  registry: LocalRegistryState | undefined,
+  localRegistry: LocalRegistryState | undefined,
+  queryRegistry: QueryBindingRegistry,
   descriptor: AnyResourceDescriptor,
   path: string,
   state: ResourceDataLike,
   runtime: ResourceRuntimeState
 ): LocalResourceBinding | undefined {
-  if (!registry) return undefined
+  if (!localRegistry) return undefined
   const metadata = getLocalResourceMetadata(descriptor)
   if (!metadata) return undefined
 
-  const existing = registry.bindings.get(state)
+  const existing = localRegistry.bindings.get(state)
   if (existing) return existing
 
   const binding = new LocalResourceBinding(
-    registry.manager,
+    localRegistry.manager,
     metadata,
     path,
     state,
     runtime,
-    descriptor
+    descriptor,
+    queryRegistry
   )
-  registry.bindings.set(state, binding)
+  localRegistry.bindings.set(state, binding)
   return binding
 }
 
@@ -1303,7 +1463,7 @@ function createLocalLifecycleFactory(): ResourceLifecycleFactory {
         registry.services.set(LOCAL_REGISTRY_SERVICE, localRegistry)
       }
 
-      const binding = bindLocalResource(localRegistry, descriptor, path, state, runtime)
+      const binding = bindLocalResource(localRegistry, registry, descriptor, path, state, runtime)
       if (!binding) return undefined
       const metadata = getLocalResourceMetadata(descriptor)
 
@@ -1321,7 +1481,9 @@ function createLocalLifecycleFactory(): ResourceLifecycleFactory {
           return binding.commitRemote(
             entry,
             fetchedAt,
-            typeof requestToken === 'number' ? requestToken : 0
+            requestToken && typeof requestToken === 'object'
+              ? (requestToken as LocalRequestToken)
+              : { revision: 0 }
           )
         },
         runInternal(callback) {

--- a/packages/comwit/src/core/local.ts
+++ b/packages/comwit/src/core/local.ts
@@ -1,11 +1,22 @@
 import { snapshot, subscribeOps, type ProxyOp } from './proxy'
+import { query } from './query/descriptor'
+import {
+  RESOURCE_LIFECYCLE,
+  RESOURCE_TYPE_OVERRIDE,
+  type ResourceLifecycleFactory,
+} from './query/types'
 import type {
   AnyResourceDescriptor,
+  InfiniteResourceBuilderOptions,
   InfiniteResourceDescriptor,
   QueryCacheEntry,
   QueryCacheKey,
+  ResourceBaseState,
   ResourceDataLike,
+  ResourceSetOptions,
   ResourceRuntimeState,
+  ResourceTypeOverride,
+  SingleResourceBuilderOptions,
   SingleResourceDescriptor,
 } from './query/types'
 
@@ -107,9 +118,65 @@ export type LocalResourceMetadata = {
   key?: string
   serializeArg?: (arg: unknown) => string
   map?: LocalDataMap<LocalEntity, unknown>
+  standalone?: boolean
+  initialData?: unknown
 }
 
+type LocalRestoreController<TState, TArg> = [TArg] extends [void]
+  ? { restore(): TState }
+  : { restore(arg: TArg): TState }
+
+type LocalActionController<TData, TArg> = [TArg] extends [void]
+  ? {
+      restore(): Promise<unknown>
+      set(data: TData, options?: ResourceSetOptions<TArg>): TData
+      remove(): TData
+    }
+  : {
+      restore(arg: TArg): Promise<unknown>
+      set(data: TData, options: ResourceSetOptions<TArg>): TData
+      remove(arg: TArg): TData
+    }
+
+export type BoundLocalResource<TData, TArg = void> = ResourceBaseState<TData> &
+  LocalActionController<TData, TArg>
+
+export type SelectableLocalResource<TData, TArg = void> = ResourceBaseState<TData> &
+  LocalRestoreController<ResourceBaseState<TData>, TArg>
+
+export type Local<TData, TArg = void> = SingleResourceDescriptor<TData, TArg> &
+  ResourceTypeOverride<BoundLocalResource<TData, TArg>, SelectableLocalResource<TData, TArg>> & {
+    selectorMethod: 'restore'
+  }
+
+export type LocalStandaloneOptions<
+  TData,
+  TArg,
+  TEntity extends LocalEntity = any,
+  TMeta = any,
+> = LocalResourceOptions<TEntity, TArg, TData, TMeta> & {
+  initialData: TData
+}
+
+export type LocalQueryOptions<
+  TData,
+  TArg,
+  TEntity extends LocalEntity = any,
+  TMeta = any,
+> = SingleResourceBuilderOptions<TData, TArg> & LocalResourceOptions<TEntity, TArg, TData, TMeta>
+
+export type LocalInfiniteOptions<
+  TData,
+  TArg,
+  TEntity extends LocalEntity = any,
+  TMeta = any,
+> = InfiniteResourceBuilderOptions<TData, TArg> & LocalResourceOptions<TEntity, TArg, TData, TMeta>
+
 export type LocalFactory = {
+  <TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+    options: LocalStandaloneOptions<TData, TArg, TEntity, TMeta>
+  ): Local<TData, TArg>
+  /** @deprecated Prefer local.query() or local.infinite(). */
   <TDescriptor extends LocalResourceDescriptor, TEntity extends LocalEntity, TMeta = unknown>(
     descriptor: TDescriptor,
     options: LocalResourceOptions<
@@ -122,6 +189,12 @@ export type LocalFactory = {
   collection<TEntity extends LocalEntity>(
     options: LocalCollectionOptions<TEntity>
   ): LocalCollection<TEntity>
+  query<TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+    options: LocalQueryOptions<TData, TArg, TEntity, TMeta>
+  ): SingleResourceDescriptor<TData, TArg>
+  infinite<TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+    options: LocalInfiniteOptions<TData, TArg, TEntity, TMeta>
+  ): InfiniteResourceDescriptor<TData, TArg>
 }
 
 function createCollection<TEntity extends LocalEntity>(
@@ -170,35 +243,115 @@ function attachLocal<
     writable: false,
   })
 
+  const existing = descriptor[RESOURCE_LIFECYCLE] ?? []
+  Object.defineProperty(descriptor, RESOURCE_LIFECYCLE, {
+    value: [...existing, createLocalLifecycleFactory()],
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+
+  if (options.serializeArg) {
+    descriptor.serializeArg = options.serializeArg as (arg: ResourceArg<TDescriptor>) => string
+  }
+
   return descriptor
 }
 
-export const local: LocalFactory = Object.assign(attachLocal, {
+function splitLocalOptions<
+  TEntity extends LocalEntity,
+  TArg,
+  TData,
+  TMeta,
+  TOptions extends LocalResourceOptions<TEntity, TArg, TData, TMeta>,
+>(options: TOptions) {
+  const { source, key, serializeArg, map, ...resourceOptions } = options
+  return {
+    resourceOptions,
+    localOptions: { source, key, serializeArg, map },
+  }
+}
+
+function createStandaloneLocal<TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+  options: LocalStandaloneOptions<TData, TArg, TEntity, TMeta>
+): Local<TData, TArg> {
+  const { initialData } = options
+  const { localOptions } = splitLocalOptions<TEntity, TArg, TData, TMeta, typeof options>(options)
+  const descriptor = query<TData, TArg>({
+    initialData,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: () => initialData,
+  }) as Local<TData, TArg>
+
+  descriptor.selectorMethod = 'restore'
+  Object.defineProperty(descriptor, RESOURCE_TYPE_OVERRIDE, {
+    value: { bound: undefined, selectable: undefined },
+    enumerable: false,
+  })
+
+  const attached = attachLocal(descriptor, localOptions)
+  const metadata = getLocalResourceMetadata(attached)!
+  metadata.standalone = true
+  metadata.initialData = initialData
+  return attached
+}
+
+function createLocalQuery<TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+  options: LocalQueryOptions<TData, TArg, TEntity, TMeta>
+): SingleResourceDescriptor<TData, TArg> {
+  const { resourceOptions, localOptions } = splitLocalOptions<
+    TEntity,
+    TArg,
+    TData,
+    TMeta,
+    typeof options
+  >(options)
+  return attachLocal(
+    query(resourceOptions as SingleResourceBuilderOptions<TData, TArg>),
+    localOptions
+  )
+}
+
+function createLocalInfinite<TData, TArg = void, TEntity extends LocalEntity = any, TMeta = any>(
+  options: LocalInfiniteOptions<TData, TArg, TEntity, TMeta>
+): InfiniteResourceDescriptor<TData, TArg> {
+  const { resourceOptions, localOptions } = splitLocalOptions<
+    TEntity,
+    TArg,
+    TData,
+    TMeta,
+    typeof options
+  >(options)
+  return attachLocal(
+    query.infinite(resourceOptions as InfiniteResourceBuilderOptions<TData, TArg>),
+    localOptions
+  )
+}
+
+function createLocal(...args: unknown[]): LocalResourceDescriptor {
+  if (args.length === 1) {
+    return createStandaloneLocal(
+      args[0] as LocalStandaloneOptions<unknown, unknown, LocalEntity, unknown>
+    )
+  }
+  return attachLocal(
+    args[0] as LocalResourceDescriptor,
+    args[1] as unknown as LocalResourceOptions<LocalEntity, unknown, unknown>
+  )
+}
+
+export const local: LocalFactory = Object.assign(createLocal, {
   collection: createCollection,
+  query: createLocalQuery,
+  infinite: createLocalInfinite,
 }) as LocalFactory
 
-export function getLocalResourceMetadata(
-  descriptor: AnyResourceDescriptor
-): LocalResourceMetadata | undefined {
+export function getLocalResourceMetadata(descriptor: object): LocalResourceMetadata | undefined {
   return (
     descriptor as AnyResourceDescriptor & {
       [LOCAL_RESOURCE_META]?: LocalResourceMetadata
     }
   )[LOCAL_RESOURCE_META]
-}
-
-export function serializeResourceArg(
-  descriptor: AnyResourceDescriptor,
-  arg: unknown,
-  fallback: (arg: unknown) => string
-): string {
-  const serialize = getLocalResourceMetadata(descriptor)?.serializeArg
-  if (!serialize) return fallback(arg)
-  const result = serialize(arg)
-  if (typeof result !== 'string') {
-    throw new Error('local() serializeArg must return a string')
-  }
-  return result
 }
 
 type DataKind = 'array' | 'entity' | 'null' | 'mapped'
@@ -595,6 +748,8 @@ export type LocalRegistryState = {
   manager: LocalManager
   bindings: WeakMap<object, LocalResourceBinding>
 }
+
+const LOCAL_REGISTRY_SERVICE = Symbol('comwit-local-registry-service')
 
 export function createLocalRegistryState(defaults?: LocalDefaults): LocalRegistryState {
   const factory =
@@ -1085,4 +1240,62 @@ export function bindLocalResource(
   )
   registry.bindings.set(state, binding)
   return binding
+}
+
+function createLocalLifecycleFactory(): ResourceLifecycleFactory {
+  return {
+    bind({ registry, descriptor, path, state, runtime }) {
+      let localRegistry = registry.services.get(LOCAL_REGISTRY_SERVICE) as
+        | LocalRegistryState
+        | undefined
+      if (!localRegistry) {
+        localRegistry = createLocalRegistryState(
+          registry.providerDefaults?.local as LocalDefaults | undefined
+        )
+        registry.services.set(LOCAL_REGISTRY_SERVICE, localRegistry)
+      }
+
+      const binding = bindLocalResource(localRegistry, descriptor, path, state, runtime)
+      if (!binding) return undefined
+      const metadata = getLocalResourceMetadata(descriptor)
+
+      return {
+        activate(key) {
+          binding.activate(key)
+        },
+        hydrate() {
+          return binding.hydrate()
+        },
+        beginRequest() {
+          return binding.currentRevision()
+        },
+        afterSuccess({ entry, fetchedAt, requestToken }) {
+          return binding.commitRemote(
+            entry,
+            fetchedAt,
+            typeof requestToken === 'number' ? requestToken : 0
+          )
+        },
+        runInternal(callback) {
+          return binding.runInternal(callback)
+        },
+        preserveSuccessOnError: true,
+        decorateController(controller) {
+          if (!metadata?.standalone) return controller
+          return new Proxy(controller, {
+            get(target, prop, receiver) {
+              if (prop === 'remove') {
+                return (arg?: unknown) => {
+                  const set = Reflect.get(target, 'set', receiver)
+                  if (typeof set !== 'function') return metadata.initialData
+                  return set.call(target, metadata.initialData, { arg })
+                }
+              }
+              return Reflect.get(target, prop, receiver)
+            },
+          })
+        },
+      }
+    },
+  }
 }

--- a/packages/comwit/src/core/local.ts
+++ b/packages/comwit/src/core/local.ts
@@ -1,0 +1,1088 @@
+import { snapshot, subscribeOps, type ProxyOp } from './proxy'
+import type {
+  AnyResourceDescriptor,
+  InfiniteResourceDescriptor,
+  QueryCacheEntry,
+  QueryCacheKey,
+  ResourceDataLike,
+  ResourceRuntimeState,
+  SingleResourceDescriptor,
+} from './query/types'
+
+const LOCAL_COLLECTION_BRAND = Symbol('comwit-local-collection')
+export const LOCAL_RESOURCE_META = Symbol('comwit-local-resource')
+
+const ENTITY_STORE = 'entities'
+const VIEW_STORE = 'views'
+const DATABASE_VERSION = 1
+const DEFAULT_DATABASE = '@comwit/state'
+const DEFAULT_SCOPE = 'default'
+
+export type LocalEntityId = string | number
+export type LocalEntity = { id: LocalEntityId } & Record<string, unknown>
+export type LocalEntityFragment<TEntity extends LocalEntity> = Pick<TEntity, 'id'> &
+  Partial<Omit<TEntity, 'id'>>
+
+export type LocalCollectionOptions<TEntity extends LocalEntity> = {
+  /** Stable persisted namespace for this entity type. */
+  key: string
+  /** App-managed schema version. Changing it invalidates and removes older rows. */
+  version: number
+  /** Advanced merge hook. The default shallowly merges fields present in the response. */
+  merge?: (
+    current: Readonly<Partial<TEntity>>,
+    incoming: Readonly<LocalEntityFragment<TEntity>>
+  ) => Partial<TEntity>
+  /** Optional server revision used to reject older list/detail responses. */
+  revision?: (entity: Readonly<Partial<TEntity>>) => string | number | undefined
+}
+
+export type LocalCollection<TEntity extends LocalEntity> = Readonly<
+  LocalCollectionOptions<TEntity> & {
+    [LOCAL_COLLECTION_BRAND]: true
+  }
+>
+
+type LocalResourceDescriptor =
+  | SingleResourceDescriptor<any, any, any>
+  | InfiniteResourceDescriptor<any, any, any>
+
+type ResourceArg<TDescriptor> = TDescriptor extends
+  | SingleResourceDescriptor<any, infer TArg, any>
+  | InfiniteResourceDescriptor<any, infer TArg, any>
+  ? TArg
+  : never
+
+type ResourceData<TDescriptor> = TDescriptor extends
+  | SingleResourceDescriptor<infer TData, any, any>
+  | InfiniteResourceDescriptor<infer TData, any, any>
+  ? TData
+  : never
+
+export type LocalDataMap<TEntity extends LocalEntity, TData, TMeta = unknown> = {
+  /** Split a query data envelope into normalized rows and cloneable view metadata. */
+  split: (data: TData) => {
+    rows: Array<LocalEntityFragment<TEntity>>
+    meta?: TMeta
+  }
+  /** Rebuild the original query data shape from canonical rows and stored metadata. */
+  join: (rows: TEntity[], meta: TMeta | undefined) => TData
+}
+
+export type LocalResourceOptions<
+  TEntity extends LocalEntity,
+  TArg = unknown,
+  TData = unknown,
+  TMeta = unknown,
+> = {
+  /** Shared entity collection used by list/detail/infinite resources. */
+  source: LocalCollection<TEntity>
+  /** Stable view identity override. Defaults to the model field path. */
+  key?: string
+  /** Override for arguments that cannot use comwit's canonical JSON serializer. */
+  serializeArg?: (arg: TArg) => string
+  /** Normalize a response envelope such as { items, total }. */
+  map?: LocalDataMap<TEntity, TData, TMeta>
+}
+
+export type LocalErrorContext = {
+  operation: 'open' | 'read' | 'write' | 'cleanup' | 'normalize'
+  collection?: string
+  resource?: string
+}
+
+export type LocalDefaults = {
+  /** Dedicated IndexedDB database name. */
+  database?: string
+  /** User/tenant boundary. Remount ComwitProvider when it changes. */
+  scope?: string
+  /** Injectable primarily for tests or browser-like runtimes. */
+  indexedDB?: IDBFactory
+  /** Storage/normalization errors degrade to normal query behavior and are reported here. */
+  onError?: (error: unknown, context: LocalErrorContext) => void
+}
+
+export type LocalResourceMetadata = {
+  source: LocalCollection<LocalEntity>
+  key?: string
+  serializeArg?: (arg: unknown) => string
+  map?: LocalDataMap<LocalEntity, unknown>
+}
+
+export type LocalFactory = {
+  <TDescriptor extends LocalResourceDescriptor, TEntity extends LocalEntity, TMeta = unknown>(
+    descriptor: TDescriptor,
+    options: LocalResourceOptions<
+      TEntity,
+      ResourceArg<TDescriptor>,
+      ResourceData<TDescriptor>,
+      TMeta
+    >
+  ): TDescriptor
+  collection<TEntity extends LocalEntity>(
+    options: LocalCollectionOptions<TEntity>
+  ): LocalCollection<TEntity>
+}
+
+function createCollection<TEntity extends LocalEntity>(
+  options: LocalCollectionOptions<TEntity>
+): LocalCollection<TEntity> {
+  if (!options.key.trim()) {
+    throw new Error('local.collection() requires a non-empty key')
+  }
+  if (!Number.isInteger(options.version) || options.version < 1) {
+    throw new Error('local.collection() requires version to be a positive integer')
+  }
+
+  return Object.freeze({
+    ...options,
+    [LOCAL_COLLECTION_BRAND]: true as const,
+  })
+}
+
+function attachLocal<
+  TDescriptor extends LocalResourceDescriptor,
+  TEntity extends LocalEntity,
+  TMeta = unknown,
+>(
+  descriptor: TDescriptor,
+  options: LocalResourceOptions<TEntity, ResourceArg<TDescriptor>, ResourceData<TDescriptor>, TMeta>
+): TDescriptor {
+  if ((descriptor as { kind: string }).kind === 'realtime') {
+    throw new Error('local() supports query() and query.infinite(), not query.realtime()')
+  }
+  if (!options.source || options.source[LOCAL_COLLECTION_BRAND] !== true) {
+    throw new Error('local() requires a source created by local.collection()')
+  }
+  if (options.key !== undefined && !options.key.trim()) {
+    throw new Error('local() key must be non-empty when provided')
+  }
+
+  Object.defineProperty(descriptor, LOCAL_RESOURCE_META, {
+    value: {
+      source: options.source as LocalCollection<LocalEntity>,
+      key: options.key,
+      serializeArg: options.serializeArg as ((arg: unknown) => string) | undefined,
+      map: options.map as LocalDataMap<LocalEntity, unknown> | undefined,
+    } satisfies LocalResourceMetadata,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+
+  return descriptor
+}
+
+export const local: LocalFactory = Object.assign(attachLocal, {
+  collection: createCollection,
+}) as LocalFactory
+
+export function getLocalResourceMetadata(
+  descriptor: AnyResourceDescriptor
+): LocalResourceMetadata | undefined {
+  return (
+    descriptor as AnyResourceDescriptor & {
+      [LOCAL_RESOURCE_META]?: LocalResourceMetadata
+    }
+  )[LOCAL_RESOURCE_META]
+}
+
+export function serializeResourceArg(
+  descriptor: AnyResourceDescriptor,
+  arg: unknown,
+  fallback: (arg: unknown) => string
+): string {
+  const serialize = getLocalResourceMetadata(descriptor)?.serializeArg
+  if (!serialize) return fallback(arg)
+  const result = serialize(arg)
+  if (typeof result !== 'string') {
+    throw new Error('local() serializeArg must return a string')
+  }
+  return result
+}
+
+type DataKind = 'array' | 'entity' | 'null' | 'mapped'
+
+type EntityRecord = {
+  key: string
+  scope: string
+  collection: string
+  version: number
+  id: LocalEntityId
+  value: LocalEntity
+  updatedAt: number
+  localRevision: number
+}
+
+type ViewRecord = {
+  key: string
+  scope: string
+  collection: string
+  version: number
+  resource: string
+  kind: 'single' | 'infinite'
+  argKey: string
+  dataKind: DataKind
+  dataMeta?: unknown
+  ids: LocalEntityId[]
+  state: Record<string, unknown>
+  fetchedAt: number
+  lastAccessedAt: number
+  cursorHistory: Array<string | null>
+  localRevision: number
+}
+
+type NormalizedState = {
+  dataKind: DataKind
+  dataMeta?: unknown
+  ids: LocalEntityId[]
+  entities: LocalEntity[]
+  state: Record<string, unknown>
+}
+
+export type LocalHydratedView = {
+  data: unknown
+  state: Record<string, unknown>
+  fetchedAt: number
+  cursorHistory: Array<string | null>
+}
+
+type ReconcileInput = {
+  incoming: NormalizedState
+  previousView?: ViewRecord
+  existing: Map<string, EntityRecord>
+  binding: LocalResourceBinding
+  fetchedAt: number
+  cursorHistory: Array<string | null>
+  local: boolean
+  dirtyIds: Set<string>
+  requestStartRevision?: number
+  mutationRevision?: number
+}
+
+type ReconcileOutput = {
+  entities: EntityRecord[]
+  view: ViewRecord
+  changedEntityKeys: Set<string>
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'))
+  })
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve()
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction failed'))
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'))
+  })
+}
+
+class LocalDatabase {
+  private databasePromise?: Promise<IDBDatabase>
+
+  constructor(
+    private readonly factory: IDBFactory,
+    private readonly name: string
+  ) {}
+
+  private open(): Promise<IDBDatabase> {
+    if (this.databasePromise) return this.databasePromise
+
+    this.databasePromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = this.factory.open(this.name, DATABASE_VERSION)
+      request.onupgradeneeded = () => {
+        const database = request.result
+        if (!database.objectStoreNames.contains(ENTITY_STORE)) {
+          database.createObjectStore(ENTITY_STORE, { keyPath: 'key' })
+        }
+        if (!database.objectStoreNames.contains(VIEW_STORE)) {
+          database.createObjectStore(VIEW_STORE, { keyPath: 'key' })
+        }
+      }
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error ?? new Error('Unable to open IndexedDB'))
+    })
+
+    return this.databasePromise
+  }
+
+  async readView(key: string): Promise<{ view: ViewRecord; entities: EntityRecord[] } | undefined> {
+    const database = await this.open()
+    const transaction = database.transaction([VIEW_STORE, ENTITY_STORE], 'readonly')
+    const completion = transactionDone(transaction)
+    try {
+      const view = (await requestResult(transaction.objectStore(VIEW_STORE).get(key))) as
+        | ViewRecord
+        | undefined
+
+      if (!view) {
+        await completion
+        return undefined
+      }
+
+      const entityStore = transaction.objectStore(ENTITY_STORE)
+      const entities = await Promise.all(
+        view.ids.map((id) =>
+          requestResult(
+            entityStore.get(entityStorageKey(view.scope, view.collection, view.version, id))
+          )
+        )
+      )
+      await completion
+
+      if (entities.some((entity) => entity === undefined)) return undefined
+      return { view, entities: entities as EntityRecord[] }
+    } catch (error) {
+      await completion.catch(() => {})
+      throw error
+    }
+  }
+
+  async reconcile(
+    viewKey: string,
+    scope: string,
+    collection: string,
+    version: number,
+    incomingIds: LocalEntityId[],
+    reconcile: (
+      previousView: ViewRecord | undefined,
+      existing: Map<string, EntityRecord>
+    ) => ReconcileOutput
+  ): Promise<ReconcileOutput> {
+    const database = await this.open()
+    const transaction = database.transaction([VIEW_STORE, ENTITY_STORE], 'readwrite')
+    const completion = transactionDone(transaction)
+    try {
+      const views = transaction.objectStore(VIEW_STORE)
+      const entities = transaction.objectStore(ENTITY_STORE)
+      const previousView = (await requestResult(views.get(viewKey))) as ViewRecord | undefined
+      const ids = new Map<string, LocalEntityId>()
+
+      for (const id of previousView?.ids ?? []) ids.set(idToken(id), id)
+      for (const id of incomingIds) ids.set(idToken(id), id)
+
+      const existing = new Map<string, EntityRecord>()
+      await Promise.all(
+        [...ids.values()].map(async (id) => {
+          const record = (await requestResult(
+            entities.get(entityStorageKey(scope, collection, version, id))
+          )) as EntityRecord | undefined
+          if (record) existing.set(idToken(id), record)
+        })
+      )
+
+      const output = reconcile(previousView, existing)
+      for (const record of output.entities) entities.put(record)
+      views.put(output.view)
+      await completion
+      return output
+    } catch (error) {
+      try {
+        transaction.abort()
+      } catch {}
+      await completion.catch(() => {})
+      throw error
+    }
+  }
+
+  async cleanupOldVersions(scope: string, collection: string, version: number): Promise<void> {
+    const database = await this.open()
+    const transaction = database.transaction([VIEW_STORE, ENTITY_STORE], 'readwrite')
+    const completion = transactionDone(transaction)
+
+    const clean = (storeName: string) =>
+      new Promise<void>((resolve, reject) => {
+        const request = transaction.objectStore(storeName).openCursor()
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'))
+        request.onsuccess = () => {
+          const cursor = request.result
+          if (!cursor) {
+            resolve()
+            return
+          }
+          const value = cursor.value as EntityRecord | ViewRecord
+          if (
+            value.scope === scope &&
+            value.collection === collection &&
+            value.version !== version
+          ) {
+            cursor.delete()
+          }
+          cursor.continue()
+        }
+      })
+
+    try {
+      await Promise.all([clean(VIEW_STORE), clean(ENTITY_STORE)])
+      await completion
+    } catch (error) {
+      try {
+        transaction.abort()
+      } catch {}
+      await completion.catch(() => {})
+      throw error
+    }
+  }
+}
+
+function idToken(id: LocalEntityId): string {
+  return `${typeof id === 'number' ? 'n' : 's'}:${String(id)}`
+}
+
+function entityStorageKey(
+  scope: string,
+  collection: string,
+  version: number,
+  id: LocalEntityId
+): string {
+  return JSON.stringify([scope, collection, version, idToken(id)])
+}
+
+function viewStorageKey(
+  scope: string,
+  collection: string,
+  version: number,
+  resource: string,
+  kind: string,
+  argKey: string
+): string {
+  return JSON.stringify([scope, collection, version, resource, kind, argKey])
+}
+
+function isEntity(value: unknown): value is LocalEntity {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const id = (value as { id?: unknown }).id
+  return typeof id === 'string' || (typeof id === 'number' && Number.isFinite(id))
+}
+
+function normalizeState(state: ResourceDataLike, metadata: LocalResourceMetadata): NormalizedState {
+  const plain = snapshot(state) as ResourceDataLike
+  const data = plain.data
+  let dataKind: DataKind
+  let entities: LocalEntity[]
+  let dataMeta: unknown
+
+  if (metadata.map) {
+    const mapped = metadata.map.split(data)
+    if (!mapped || !Array.isArray(mapped.rows) || !mapped.rows.every(isEntity)) {
+      throw new Error('local() map.split() must return entity rows with string or number ids')
+    }
+    dataKind = 'mapped'
+    entities = mapped.rows as LocalEntity[]
+    dataMeta = mapped.meta
+  } else if (data === null) {
+    dataKind = 'null'
+    entities = []
+  } else if (Array.isArray(data)) {
+    if (!data.every(isEntity)) {
+      throw new Error('local() array data must contain objects with a string or number id')
+    }
+    dataKind = 'array'
+    entities = data as LocalEntity[]
+  } else if (isEntity(data)) {
+    dataKind = 'entity'
+    entities = [data]
+  } else {
+    throw new Error('local() data must be an entity, an entity array, or null')
+  }
+
+  const stateMeta: Record<string, unknown> = { ...plain }
+  delete stateMeta.data
+  delete stateMeta.isLoading
+  delete stateMeta.isFetching
+  delete stateMeta.isSuccess
+  delete stateMeta.isError
+  delete stateMeta.error
+
+  return {
+    dataKind,
+    dataMeta,
+    ids: entities.map((entity) => entity.id),
+    entities,
+    state: stateMeta,
+  }
+}
+
+function hydrateData(
+  view: ViewRecord,
+  records: EntityRecord[],
+  metadata: LocalResourceMetadata
+): unknown {
+  if (view.dataKind === 'null') return null
+  if (view.dataKind === 'entity') return records[0]?.value ?? null
+  if (view.dataKind === 'mapped') {
+    if (!metadata.map) {
+      throw new Error('local() view requires the map option that created it')
+    }
+    return metadata.map.join(
+      records.map((record) => record.value),
+      view.dataMeta
+    )
+  }
+  return records.map((record) => record.value)
+}
+
+function compareRevision(
+  collection: LocalCollection<LocalEntity>,
+  current: LocalEntity,
+  incoming: LocalEntity
+): number {
+  if (!collection.revision) return 0
+  const currentRevision = collection.revision(current)
+  const incomingRevision = collection.revision(incoming)
+  if (currentRevision === undefined || incomingRevision === undefined) return 0
+  if (incomingRevision < currentRevision) return -1
+  if (incomingRevision > currentRevision) return 1
+  return 0
+}
+
+function mergeEntity(
+  collection: LocalCollection<LocalEntity>,
+  current: LocalEntity | undefined,
+  incoming: LocalEntity
+): LocalEntity {
+  if (!current) return { ...incoming }
+  if (compareRevision(collection, current, incoming) < 0) return current
+  if (collection.merge) {
+    const merged = collection.merge(current, incoming)
+    return { ...merged, id: incoming.id } as LocalEntity
+  }
+  return { ...current, ...incoming }
+}
+
+function idsFromOp(
+  op: ProxyOp | undefined,
+  state: ResourceDataLike,
+  metadata: LocalResourceMetadata
+): Set<string> {
+  const ids = new Set<string>()
+  if (!op || op[1][0] !== 'data') return ids
+
+  const add = (value: unknown) => {
+    if (isEntity(value)) ids.add(idToken(value.id))
+    if (Array.isArray(value)) {
+      for (const item of value) if (isEntity(item)) ids.add(idToken(item.id))
+    }
+  }
+
+  add(op[0] === 'set' ? op[2] : undefined)
+  add(op[0] === 'set' ? op[3] : op[2])
+
+  const data = state.data
+  const index = op[1][1]
+  if (Array.isArray(data) && (typeof index === 'string' || typeof index === 'number')) {
+    add(data[Number(index)])
+  } else {
+    add(data)
+  }
+
+  if (ids.size === 0 && metadata.map) {
+    const plain = snapshot(state) as ResourceDataLike
+    const mapped = metadata.map.split(plain.data)
+    add(mapped.rows)
+  }
+
+  return ids
+}
+
+export type LocalRegistryState = {
+  manager: LocalManager
+  bindings: WeakMap<object, LocalResourceBinding>
+}
+
+export function createLocalRegistryState(defaults?: LocalDefaults): LocalRegistryState {
+  const factory =
+    defaults?.indexedDB ?? (typeof globalThis !== 'undefined' ? globalThis.indexedDB : undefined)
+  return {
+    manager: new LocalManager(defaults, factory),
+    bindings: new WeakMap(),
+  }
+}
+
+class LocalManager {
+  readonly scope: string
+  private readonly database?: LocalDatabase
+  private readonly onError?: LocalDefaults['onError']
+  private readonly bindings = new Set<LocalResourceBinding>()
+  private readonly entityCache = new Map<string, EntityRecord>()
+  private readonly viewCache = new Map<string, ViewRecord>()
+  private readonly collectionRevisions = new Map<string, number>()
+  private readonly cleanedVersions = new Set<string>()
+  private writeTail: Promise<void> = Promise.resolve()
+
+  constructor(defaults: LocalDefaults | undefined, factory: IDBFactory | undefined) {
+    this.scope = defaults?.scope ?? DEFAULT_SCOPE
+    this.onError = defaults?.onError
+    if (factory) {
+      this.database = new LocalDatabase(factory, defaults?.database ?? DEFAULT_DATABASE)
+    }
+  }
+
+  register(binding: LocalResourceBinding): void {
+    this.bindings.add(binding)
+  }
+
+  revision(collection: LocalCollection<LocalEntity>): number {
+    return this.collectionRevisions.get(this.collectionNamespace(collection)) ?? 0
+  }
+
+  markLocalMutation(collection: LocalCollection<LocalEntity>): number {
+    const namespace = this.collectionNamespace(collection)
+    const revision = (this.collectionRevisions.get(namespace) ?? 0) + 1
+    this.collectionRevisions.set(namespace, revision)
+    return revision
+  }
+
+  private collectionNamespace(collection: LocalCollection<LocalEntity>): string {
+    return JSON.stringify([this.scope, collection.key, collection.version])
+  }
+
+  private entityCacheKey(collection: LocalCollection<LocalEntity>, id: LocalEntityId): string {
+    return JSON.stringify([this.collectionNamespace(collection), idToken(id)])
+  }
+
+  private report(error: unknown, context: LocalErrorContext): void {
+    this.onError?.(error, context)
+  }
+
+  private async ensureVersion(collection: LocalCollection<LocalEntity>): Promise<void> {
+    if (!this.database) return
+    const namespace = this.collectionNamespace(collection)
+    if (this.cleanedVersions.has(namespace)) return
+    this.cleanedVersions.add(namespace)
+    try {
+      await this.database.cleanupOldVersions(this.scope, collection.key, collection.version)
+    } catch (error) {
+      this.report(error, { operation: 'cleanup', collection: collection.key })
+    }
+  }
+
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.writeTail.then(task, task)
+    this.writeTail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  async hydrate(binding: LocalResourceBinding): Promise<LocalHydratedView | undefined> {
+    if (!this.database || !binding.activeView) return undefined
+    await this.writeTail
+    await this.ensureVersion(binding.metadata.source)
+
+    try {
+      const stored = await this.database.readView(binding.activeView.key)
+      if (!stored) return undefined
+
+      stored.view.lastAccessedAt = Date.now()
+      this.viewCache.set(stored.view.key, stored.view)
+      for (const record of stored.entities) {
+        this.entityCache.set(this.entityCacheKey(binding.metadata.source, record.id), record)
+        const currentRevision = this.revision(binding.metadata.source)
+        if (record.localRevision > currentRevision) {
+          this.collectionRevisions.set(
+            this.collectionNamespace(binding.metadata.source),
+            record.localRevision
+          )
+        }
+      }
+
+      return {
+        data: hydrateData(stored.view, stored.entities, binding.metadata),
+        state: stored.view.state,
+        fetchedAt: stored.view.fetchedAt,
+        cursorHistory: [...stored.view.cursorHistory],
+      }
+    } catch (error) {
+      this.report(error, {
+        operation: 'read',
+        collection: binding.metadata.source.key,
+        resource: binding.resource,
+      })
+      return undefined
+    }
+  }
+
+  async commitRemote(
+    binding: LocalResourceBinding,
+    entry: QueryCacheEntry,
+    fetchedAt: number,
+    requestStartRevision: number
+  ): Promise<void> {
+    await this.commit(binding, entry, fetchedAt, false, new Set(), requestStartRevision)
+  }
+
+  async commitLocal(
+    binding: LocalResourceBinding,
+    dirtyIds: Set<string>,
+    mutationRevision: number
+  ): Promise<void> {
+    const entry = binding.activeEntry()
+    if (!entry) return
+    await this.commit(
+      binding,
+      entry,
+      entry.lastFetchedAt,
+      true,
+      dirtyIds,
+      undefined,
+      mutationRevision
+    )
+  }
+
+  private async commit(
+    binding: LocalResourceBinding,
+    entry: QueryCacheEntry,
+    fetchedAt: number,
+    local: boolean,
+    dirtyIds: Set<string>,
+    requestStartRevision?: number,
+    mutationRevision?: number
+  ): Promise<void> {
+    if (!binding.activeView) return
+
+    let incoming: NormalizedState
+    try {
+      incoming = normalizeState(binding.state, binding.metadata)
+    } catch (error) {
+      this.report(error, {
+        operation: 'normalize',
+        collection: binding.metadata.source.key,
+        resource: binding.resource,
+      })
+      return
+    }
+
+    const reconcile = (
+      previousView: ViewRecord | undefined,
+      existingFromStore: Map<string, EntityRecord>
+    ): ReconcileOutput => {
+      const input: ReconcileInput = {
+        incoming,
+        previousView,
+        existing: existingFromStore,
+        binding,
+        fetchedAt,
+        cursorHistory: [...entry.cursorHistory],
+        local,
+        dirtyIds,
+        requestStartRevision,
+        mutationRevision,
+      }
+      return this.reconcile(input)
+    }
+
+    let output: ReconcileOutput
+    try {
+      output = await this.enqueue(async () => {
+        await this.ensureVersion(binding.metadata.source)
+        if (this.database) {
+          return this.database.reconcile(
+            binding.activeView!.key,
+            this.scope,
+            binding.metadata.source.key,
+            binding.metadata.source.version,
+            incoming.ids,
+            reconcile
+          )
+        }
+        return reconcile(this.viewCache.get(binding.activeView!.key), new Map())
+      })
+    } catch (error) {
+      this.report(error, {
+        operation: 'write',
+        collection: binding.metadata.source.key,
+        resource: binding.resource,
+      })
+      output = reconcile(this.viewCache.get(binding.activeView.key), new Map())
+    }
+
+    this.viewCache.set(output.view.key, output.view)
+    for (const record of output.entities) {
+      this.entityCache.set(this.entityCacheKey(binding.metadata.source, record.id), record)
+    }
+
+    if (!local) {
+      const byId = new Map(output.entities.map((record) => [idToken(record.id), record]))
+      const ordered = output.view.ids
+        .map(
+          (id) =>
+            byId.get(idToken(id)) ??
+            this.entityCache.get(this.entityCacheKey(binding.metadata.source, id))
+        )
+        .filter((record): record is EntityRecord => record !== undefined)
+      if (ordered.length === output.view.ids.length) {
+        binding.applyView(output.view, ordered)
+      }
+    }
+
+    const changed = output.entities.filter((record) =>
+      output.changedEntityKeys.has(idToken(record.id))
+    )
+    this.fanOut(binding.metadata.source, changed, binding)
+  }
+
+  private reconcile(input: ReconcileInput): ReconcileOutput {
+    const { binding, incoming, previousView, local, requestStartRevision } = input
+    const collection = binding.metadata.source
+    const namespace = this.collectionNamespace(collection)
+    const localRevision = input.mutationRevision ?? this.collectionRevisions.get(namespace) ?? 0
+
+    const existing = new Map(input.existing)
+    for (const id of new Set([...incoming.ids, ...(previousView?.ids ?? [])])) {
+      const cached = this.entityCache.get(this.entityCacheKey(collection, id))
+      if (cached) existing.set(idToken(id), cached)
+    }
+
+    const records: EntityRecord[] = []
+    const changedEntityKeys = new Set<string>()
+
+    for (const entity of incoming.entities) {
+      const token = idToken(entity.id)
+      const current = existing.get(token)
+      const protectLocal =
+        !local &&
+        requestStartRevision !== undefined &&
+        current !== undefined &&
+        current.localRevision > requestStartRevision
+      const nextValue = protectLocal
+        ? current.value
+        : mergeEntity(collection, current?.value, entity)
+      const nextLocalRevision =
+        local && input.dirtyIds.has(token) ? localRevision : (current?.localRevision ?? 0)
+      const record: EntityRecord = {
+        key: entityStorageKey(this.scope, collection.key, collection.version, entity.id),
+        scope: this.scope,
+        collection: collection.key,
+        version: collection.version,
+        id: entity.id,
+        value: nextValue,
+        updatedAt: Date.now(),
+        localRevision: nextLocalRevision,
+      }
+      records.push(record)
+      if (!current || current.value !== nextValue || nextLocalRevision !== current.localRevision) {
+        changedEntityKeys.add(token)
+      }
+    }
+
+    const protectLocalView =
+      !local &&
+      requestStartRevision !== undefined &&
+      previousView !== undefined &&
+      previousView.localRevision > requestStartRevision
+
+    const ids = protectLocalView ? [...previousView.ids] : [...incoming.ids]
+    if (protectLocalView) {
+      for (const id of previousView.ids) {
+        const current = existing.get(idToken(id))
+        if (current && !records.some((record) => idToken(record.id) === idToken(id))) {
+          records.push(current)
+        }
+      }
+    }
+
+    const view: ViewRecord = {
+      ...binding.activeView!,
+      dataKind: protectLocalView ? previousView.dataKind : incoming.dataKind,
+      dataMeta: protectLocalView ? previousView.dataMeta : incoming.dataMeta,
+      ids,
+      state: protectLocalView ? previousView.state : incoming.state,
+      fetchedAt: protectLocalView ? previousView.fetchedAt : input.fetchedAt,
+      lastAccessedAt: Date.now(),
+      cursorHistory: protectLocalView ? previousView.cursorHistory : input.cursorHistory,
+      localRevision: local ? localRevision : protectLocalView ? previousView.localRevision : 0,
+    }
+
+    return { entities: records, view, changedEntityKeys }
+  }
+
+  fanOut(
+    collection: LocalCollection<LocalEntity>,
+    records: EntityRecord[],
+    source?: LocalResourceBinding
+  ): void {
+    if (records.length === 0) return
+    for (const binding of this.bindings) {
+      if (
+        binding === source ||
+        binding.metadata.source.key !== collection.key ||
+        binding.metadata.source.version !== collection.version
+      ) {
+        continue
+      }
+      binding.applyEntities(records)
+    }
+    source?.applyEntities(records)
+  }
+}
+
+type ActiveView = Omit<
+  ViewRecord,
+  'dataKind' | 'ids' | 'state' | 'fetchedAt' | 'lastAccessedAt' | 'cursorHistory' | 'localRevision'
+>
+
+export class LocalResourceBinding {
+  activeView?: ActiveView
+  private suppress = 0
+  private pendingMutation = false
+  private pendingMutationRevision = 0
+  private readonly dirtyIds = new Set<string>()
+
+  constructor(
+    readonly manager: LocalManager,
+    readonly metadata: LocalResourceMetadata,
+    readonly resource: string,
+    readonly state: ResourceDataLike,
+    readonly runtime: ResourceRuntimeState,
+    readonly descriptor: AnyResourceDescriptor
+  ) {
+    manager.register(this)
+    subscribeOps(state, (op) => this.onOperation(op))
+  }
+
+  runInternal<T>(callback: () => T): T {
+    this.suppress++
+    try {
+      return callback()
+    } finally {
+      this.suppress--
+    }
+  }
+
+  activate(argKey: QueryCacheKey): void {
+    const source = this.metadata.source
+    const resource = this.metadata.key ?? this.resource
+    this.activeView = {
+      key: viewStorageKey(
+        this.manager.scope,
+        source.key,
+        source.version,
+        resource,
+        this.descriptor.kind,
+        argKey
+      ),
+      scope: this.manager.scope,
+      collection: source.key,
+      version: source.version,
+      resource,
+      kind: this.descriptor.kind as 'single' | 'infinite',
+      argKey,
+    }
+  }
+
+  activeEntry(): QueryCacheEntry | undefined {
+    if (!this.runtime.activeKey) return undefined
+    return this.runtime.cacheEntries.get(this.runtime.activeKey)
+  }
+
+  currentRevision(): number {
+    return this.manager.revision(this.metadata.source)
+  }
+
+  async hydrate(): Promise<LocalHydratedView | undefined> {
+    const hydrated = await this.manager.hydrate(this)
+    if (!hydrated) return undefined
+    return hydrated
+  }
+
+  async commitRemote(
+    entry: QueryCacheEntry,
+    fetchedAt: number,
+    requestStartRevision: number
+  ): Promise<void> {
+    await this.manager.commitRemote(this, entry, fetchedAt, requestStartRevision)
+  }
+
+  syncActiveCache(): void {
+    const entry = this.activeEntry()
+    if (!entry) return
+    entry.state = snapshot(this.state) as ResourceDataLike
+  }
+
+  applyView(view: ViewRecord, records: EntityRecord[]): void {
+    this.runInternal(() => {
+      this.state.data = hydrateData(view, records, this.metadata)
+      Object.assign(this.state, view.state)
+    })
+    this.syncActiveCache()
+  }
+
+  applyEntities(records: EntityRecord[]): void {
+    if (records.length === 0) return
+    const byId = new Map(records.map((record) => [idToken(record.id), record.value]))
+
+    this.runInternal(() => {
+      const data = this.state.data
+      if (this.metadata.map) {
+        const plain = snapshot(this.state) as ResourceDataLike
+        const mapped = this.metadata.map.split(plain.data)
+        const rows = mapped.rows.map((item) => {
+          const next = byId.get(idToken(item.id))
+          return (next ?? item) as LocalEntity
+        })
+        this.state.data = this.metadata.map.join(rows, mapped.meta)
+      } else if (Array.isArray(data)) {
+        for (const item of data) {
+          if (!isEntity(item)) continue
+          const next = byId.get(idToken(item.id))
+          if (next) Object.assign(item, next)
+        }
+      } else if (isEntity(data)) {
+        const next = byId.get(idToken(data.id))
+        if (next) Object.assign(data, next)
+      }
+    })
+    this.syncActiveCache()
+  }
+
+  private onOperation(op: ProxyOp | undefined): void {
+    if (this.suppress > 0 || !op || op[1][0] !== 'data') return
+    for (const id of idsFromOp(op, this.state, this.metadata)) this.dirtyIds.add(id)
+    if (this.pendingMutation) return
+    this.pendingMutation = true
+    this.pendingMutationRevision = this.manager.markLocalMutation(this.metadata.source)
+
+    queueMicrotask(() => {
+      this.pendingMutation = false
+      const dirty = new Set(this.dirtyIds)
+      const mutationRevision = this.pendingMutationRevision
+      this.dirtyIds.clear()
+      this.syncActiveCache()
+      void this.manager.commitLocal(this, dirty, mutationRevision)
+    })
+  }
+}
+
+export function bindLocalResource(
+  registry: LocalRegistryState | undefined,
+  descriptor: AnyResourceDescriptor,
+  path: string,
+  state: ResourceDataLike,
+  runtime: ResourceRuntimeState
+): LocalResourceBinding | undefined {
+  if (!registry) return undefined
+  const metadata = getLocalResourceMetadata(descriptor)
+  if (!metadata) return undefined
+
+  const existing = registry.bindings.get(state)
+  if (existing) return existing
+
+  const binding = new LocalResourceBinding(
+    registry.manager,
+    metadata,
+    path,
+    state,
+    runtime,
+    descriptor
+  )
+  registry.bindings.set(state, binding)
+  return binding
+}

--- a/packages/comwit/src/core/plugin.ts
+++ b/packages/comwit/src/core/plugin.ts
@@ -24,7 +24,10 @@ export type FieldPlugin = {
    * Called once per provider to create plugin-level registry state.
    * For query plugin, this creates the QueryBindingRegistry.
    */
-  createRegistryState(defaults?: Record<string, unknown>): unknown
+  createRegistryState(
+    defaults?: Record<string, unknown>,
+    allDefaults?: Record<string, unknown>
+  ): unknown
 
   /**
    * Called when action's state() binds a model proxy.

--- a/packages/comwit/src/core/provider.tsx
+++ b/packages/comwit/src/core/provider.tsx
@@ -4,6 +4,7 @@ import type { Model, StoreEntry } from './model'
 import type { StageMethodDecorator } from '../interceptors/utils'
 import { getDevTools, initDevTools } from './devtools'
 import type { LocalDefaults } from './local'
+import type { QueryBindingRegistry } from './query/types'
 
 export type RegistryDefaults = {
   interceptors?: StageMethodDecorator[]
@@ -103,6 +104,12 @@ export function ComwitProvider({ children, defaultOptions, context = {} }: Comwi
         registryRef.current.lifecycles.set(model.key, state)
         return state
       },
+    }
+
+    const queryRegistry = pluginStates.get('query') as QueryBindingRegistry | undefined
+    if (queryRegistry) {
+      queryRegistry.getModelState = (source) =>
+        registryRef.current.get(source as Model<object>).proxy
     }
   }
 

--- a/packages/comwit/src/core/provider.tsx
+++ b/packages/comwit/src/core/provider.tsx
@@ -3,9 +3,11 @@ import { getPlugins } from './plugin'
 import type { Model, StoreEntry } from './model'
 import type { StageMethodDecorator } from '../interceptors/utils'
 import { getDevTools, initDevTools } from './devtools'
+import type { LocalDefaults } from './local'
 
 export type RegistryDefaults = {
   interceptors?: StageMethodDecorator[]
+  local?: LocalDefaults
   [pluginName: string]: unknown
 }
 
@@ -65,7 +67,10 @@ export function ComwitProvider({ children, defaultOptions, context = {} }: Comwi
     for (const plugin of plugins) {
       const defaults = defaultOptions?.[plugin.name] as Record<string, unknown> | undefined
       pluginDefaults.set(plugin.name, defaults)
-      pluginStates.set(plugin.name, plugin.createRegistryState(defaults))
+      pluginStates.set(
+        plugin.name,
+        plugin.createRegistryState(defaults, defaultOptions as Record<string, unknown> | undefined)
+      )
     }
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -1,7 +1,7 @@
 import { snapshot } from '../proxy'
-import { bindLocalResource, serializeResourceArg } from '../local'
 import { DEFAULT_GC_TIME } from './registry'
 import {
+  RESOURCE_LIFECYCLE,
   RESOURCE_QUERY_OPTION_KEYS,
   type AnyResourceDescriptor,
   type ConnectionStatus,
@@ -17,10 +17,12 @@ import {
   type ResourceContext,
   type ResourceDataLike,
   type ResourceInfiniteState,
+  type ResourceLifecycleBinding,
   type ResourceQueryOptions,
   type ResourceRealtimeState,
   type ResourceRuntimeState,
   type ResourceSingleState,
+  type ResourceSetOptions,
   type SingleResourceDescriptor,
   type SubscribeCallbacks,
 } from './types'
@@ -154,6 +156,16 @@ export function serializeQueryArg(arg: unknown) {
   } catch {
     return `__unserializable__:${String(arg)}`
   }
+}
+
+export function serializeResourceArg(descriptor: AnyResourceDescriptor, arg: unknown): string {
+  const serialize = descriptor.serializeArg as ((value: unknown) => string) | undefined
+  if (!serialize) return serializeQueryArg(arg)
+  const result = serialize(arg)
+  if (typeof result !== 'string') {
+    throw new Error('resource serializeArg must return a string')
+  }
+  return result
 }
 
 function cloneRuntime(path: string): ResourceRuntimeState {
@@ -299,9 +311,40 @@ export function createResourceAccessor(
   })
   registry.boundResourceRuntime.set(state, runtime)
 
-  const localBinding = bindLocalResource(registry.local, descriptor, path, state, runtime)
-  const runInternal = <T>(callback: () => T): T =>
-    localBinding ? localBinding.runInternal(callback) : callback()
+  const lifecycleBindings = (descriptor[RESOURCE_LIFECYCLE] ?? [])
+    .map((factory) => factory.bind({ state, descriptor, path, runtime, registry }))
+    .filter((binding): binding is ResourceLifecycleBinding => binding !== undefined)
+
+  const runInternal = <T>(callback: () => T): T => {
+    const visit = (index: number): T => {
+      const binding = lifecycleBindings[index]
+      if (!binding) return callback()
+      return binding.runInternal ? binding.runInternal(() => visit(index + 1)) : visit(index + 1)
+    }
+    return visit(0)
+  }
+
+  const activateLifecycle = (key: string, arg: unknown) => {
+    for (const binding of lifecycleBindings) binding.activate?.(key, arg)
+  }
+
+  const beginLifecycleRequests = () => lifecycleBindings.map((binding) => binding.beginRequest?.())
+
+  const commitLifecycleSuccess = async (
+    entry: QueryCacheEntry,
+    fetchedAt: number,
+    requestTokens: unknown[]
+  ) => {
+    await Promise.all(
+      lifecycleBindings.map((binding, index) =>
+        binding.afterSuccess?.({
+          entry,
+          fetchedAt,
+          requestToken: requestTokens[index],
+        })
+      )
+    )
+  }
 
   if (modelKey !== undefined) {
     let set = registry.runtimesByModel.get(modelKey)
@@ -402,10 +445,10 @@ export function createResourceAccessor(
     const now = Date.now()
 
     const queryArg = isRefetch ? activeEntryBefore?.arg : hasArg ? arg : runtime.lastArg
-    const queryKey = serializeResourceArg(descriptor, queryArg, serializeQueryArg)
+    const queryKey = serializeResourceArg(descriptor, queryArg)
     runtime.lastArg = queryArg
     runtime.activeKey = queryKey
-    localBinding?.activate(queryKey)
+    activateLifecycle(queryKey, queryArg)
 
     let entry = runtime.cacheEntries.get(queryKey)
     if (!entry) {
@@ -423,9 +466,8 @@ export function createResourceAccessor(
 
     const currentFetchId = ++runtime.fetchId
 
-    // A local query first checks the exact durable view for this resource/argument.
-    // The view proves list membership/detail completeness; an entity row by itself does not.
-    if (localBinding && !entry.localHydrated && !entry.hasQueried) {
+    // Lifecycle adapters may restore an exact durable view before the remote driver runs.
+    if (lifecycleBindings.length > 0 && !entry.resourceHydrated && !entry.hasQueried) {
       const isArgChange = !isRefetch && activeEntryBefore?.hasQueried
       const hasPlaceholderData = effectiveOptions.placeholderData !== undefined
 
@@ -445,9 +487,13 @@ export function createResourceAccessor(
       state.isLoading = !state.isSuccess
       state.isFetching = true
 
-      const hydrated = await localBinding.hydrate()
+      let hydrated
+      for (const binding of lifecycleBindings) {
+        hydrated = await binding.hydrate?.()
+        if (hydrated) break
+      }
       if (runtime.fetchId !== currentFetchId) return
-      entry.localHydrated = true
+      entry.resourceHydrated = true
 
       if (hydrated) {
         runInternal(() => {
@@ -461,11 +507,12 @@ export function createResourceAccessor(
         })
         entry.hasQueried = true
         entry.lastFetchedAt = hydrated.fetchedAt
-        entry.cursorHistory = [...hydrated.cursorHistory]
+        entry.cursorHistory = [...(hydrated.cursorHistory ?? [])]
         entry.lastResult =
-          descriptor.kind === 'infinite'
+          hydrated.lastResult ??
+          (descriptor.kind === 'infinite'
             ? { data: hydrated.data, ...hydrated.state }
-            : hydrated.data
+            : hydrated.data)
         updateCachedState(entry, state)
       }
     }
@@ -551,7 +598,7 @@ export function createResourceAccessor(
       runtime.streamAbortController = undefined
     }
 
-    const requestStartRevision = localBinding?.currentRevision() ?? 0
+    const requestTokens = beginLifecycleRequests()
 
     try {
       let result: unknown
@@ -621,9 +668,7 @@ export function createResourceAccessor(
         state.isSuccess = true
         entry.lastFetchedAt = Date.now()
         entry.lastResult = lastYield
-        if (localBinding) {
-          await localBinding.commitRemote(entry, entry.lastFetchedAt, requestStartRevision)
-        }
+        await commitLifecycleSuccess(entry, entry.lastFetchedAt, requestTokens)
         updateCachedState(entry, state)
 
         scheduleRefetchInterval()
@@ -653,9 +698,7 @@ export function createResourceAccessor(
         }
       }
 
-      if (localBinding) {
-        await localBinding.commitRemote(entry, entry.lastFetchedAt, requestStartRevision)
-      }
+      await commitLifecycleSuccess(entry, entry.lastFetchedAt, requestTokens)
       updateCachedState(entry, state)
 
       if (descriptor.kind === 'realtime') {
@@ -670,7 +713,8 @@ export function createResourceAccessor(
         throw error
       }
       state.isError = true
-      state.isSuccess = localBinding && entry.hasQueried ? true : false
+      state.isSuccess =
+        entry.hasQueried && lifecycleBindings.some((binding) => binding.preserveSuccessOnError)
       state.error = normalizeError(error)
 
       // Store error in suspense state for ErrorBoundary
@@ -795,9 +839,68 @@ export function createResourceAccessor(
     }
   }
 
-  const bound = new Proxy(state, {
+  const setResource = (next: unknown, options?: ResourceSetOptions<unknown>): unknown => {
+    const setArg =
+      options && Object.prototype.hasOwnProperty.call(options, 'arg')
+        ? options.arg
+        : runtime.lastArg
+    const key = serializeResourceArg(descriptor, setArg)
+
+    // A server initializer must win over an IndexedDB restore or request that
+    // started before it. Advancing fetchId invalidates either pending result.
+    runtime.fetchId++
+    runtime.lastArg = setArg
+    runtime.activeKey = key
+    activateLifecycle(key, setArg)
+
+    let entry = runtime.cacheEntries.get(key)
+    if (!entry) {
+      entry = createCacheEntry(state, key, setArg)
+      runtime.cacheEntries.set(key, entry)
+    }
+    entry.arg = setArg
+
+    const stateKeys = new Set([
+      'data',
+      'isLoading',
+      'isFetching',
+      'isSuccess',
+      'isError',
+      'error',
+      'cursor',
+      'hasMore',
+    ])
+    const nextKeys = isRecord(next) ? Object.keys(next) : []
+    const isStatePatch =
+      nextKeys.length > 0 &&
+      nextKeys.some((key) => stateKeys.has(key)) &&
+      nextKeys.every((key) => stateKeys.has(key))
+
+    if (isStatePatch) {
+      Object.assign(state, next)
+    } else {
+      state.data = next
+    }
+
+    state.isLoading = false
+    state.isFetching = false
+    state.isSuccess = true
+    state.isError = false
+    state.error = null
+
+    entry.hasQueried = true
+    entry.resourceHydrated = true
+    entry.lastFetchedAt = Date.now()
+    entry.lastResult = state.data
+    updateCachedState(entry, state)
+
+    return next
+  }
+
+  const baseBound = new Proxy(state, {
     get(target, prop) {
       if (prop === 'query') return queryFn
+      if (descriptor.selectorMethod && prop === descriptor.selectorMethod) return queryFn
       if (prop === 'refetch') return refetch
       if (prop === 'unsubscribe') {
         if (descriptor.kind === 'realtime') return unsubscribe
@@ -812,29 +915,17 @@ export function createResourceAccessor(
         return undefined
       }
       if (prop === 'set') {
-        return (next: unknown) => {
-          if (isRecord(next)) {
-            Object.assign(target, next)
-          } else {
-            target.data = next
-          }
-
-          target.isSuccess = true
-          target.isError = false
-          target.error = null
-
-          const activeEntry = getActiveEntry()
-          if (activeEntry) {
-            updateCachedState(activeEntry, target)
-          }
-
-          return next
-        }
+        return setResource
       }
 
       return Reflect.get(target, prop)
     },
   })
+
+  const bound = lifecycleBindings.reduce(
+    (controller, binding) => binding.decorateController?.(controller) ?? controller,
+    baseBound as ResourceDataLike
+  )
 
   registry.boundResourceValue.set(state, bound)
   registry.boundResourceRuntime.set(bound, runtime)

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -1,4 +1,5 @@
 import { snapshot } from '../proxy'
+import { bindLocalResource, serializeResourceArg } from '../local'
 import { DEFAULT_GC_TIME } from './registry'
 import {
   RESOURCE_QUERY_OPTION_KEYS,
@@ -183,7 +184,9 @@ function createCacheEntry(
 }
 
 function applyCachedState(target: ResourceDataLike, cached: QueryCacheEntry) {
-  Object.assign(target, cached.state)
+  // snapshot() is intentionally frozen. Clone it before placing it back into
+  // the mutable proxy or nested optimistic edits would hit read-only objects.
+  Object.assign(target, structuredClone(cached.state))
   target.isLoading = false
   target.isFetching = false
 }
@@ -296,6 +299,10 @@ export function createResourceAccessor(
   })
   registry.boundResourceRuntime.set(state, runtime)
 
+  const localBinding = bindLocalResource(registry.local, descriptor, path, state, runtime)
+  const runInternal = <T>(callback: () => T): T =>
+    localBinding ? localBinding.runInternal(callback) : callback()
+
   if (modelKey !== undefined) {
     let set = registry.runtimesByModel.get(modelKey)
     if (!set) {
@@ -395,9 +402,10 @@ export function createResourceAccessor(
     const now = Date.now()
 
     const queryArg = isRefetch ? activeEntryBefore?.arg : hasArg ? arg : runtime.lastArg
-    const queryKey = serializeQueryArg(queryArg)
+    const queryKey = serializeResourceArg(descriptor, queryArg, serializeQueryArg)
     runtime.lastArg = queryArg
     runtime.activeKey = queryKey
+    localBinding?.activate(queryKey)
 
     let entry = runtime.cacheEntries.get(queryKey)
     if (!entry) {
@@ -413,6 +421,55 @@ export function createResourceAccessor(
 
     entry.arg = queryArg
 
+    const currentFetchId = ++runtime.fetchId
+
+    // A local query first checks the exact durable view for this resource/argument.
+    // The view proves list membership/detail completeness; an entity row by itself does not.
+    if (localBinding && !entry.localHydrated && !entry.hasQueried) {
+      const isArgChange = !isRefetch && activeEntryBefore?.hasQueried
+      const hasPlaceholderData = effectiveOptions.placeholderData !== undefined
+
+      if (isArgChange && !hasPlaceholderData) {
+        runInternal(() => Object.assign(state, descriptor.initialState))
+      }
+      runInternal(() =>
+        applyPlaceholderData(
+          state as ResourceBaseState<unknown>,
+          queryArg as never,
+          effectiveOptions.placeholderData as PlaceholderData<unknown, unknown> | undefined
+        )
+      )
+
+      state.isError = false
+      state.error = null
+      state.isLoading = !state.isSuccess
+      state.isFetching = true
+
+      const hydrated = await localBinding.hydrate()
+      if (runtime.fetchId !== currentFetchId) return
+      entry.localHydrated = true
+
+      if (hydrated) {
+        runInternal(() => {
+          state.data = hydrated.data
+          Object.assign(state, hydrated.state)
+          state.isLoading = false
+          state.isFetching = false
+          state.isSuccess = true
+          state.isError = false
+          state.error = null
+        })
+        entry.hasQueried = true
+        entry.lastFetchedAt = hydrated.fetchedAt
+        entry.cursorHistory = [...hydrated.cursorHistory]
+        entry.lastResult =
+          descriptor.kind === 'infinite'
+            ? { data: hydrated.data, ...hydrated.state }
+            : hydrated.data
+        updateCachedState(entry, state)
+      }
+    }
+
     const shouldFetch =
       isRefetch ||
       !entry.hasQueried ||
@@ -421,12 +478,12 @@ export function createResourceAccessor(
       now - entry.lastFetchedAt >= staleTime
 
     if (!shouldFetch && entry.hasQueried) {
-      applyCachedState(state, entry)
+      runInternal(() => applyCachedState(state, entry))
       return entry.lastResult
     }
 
     if (entry.hasQueried) {
-      applyCachedState(state, entry)
+      runInternal(() => applyCachedState(state, entry))
     }
 
     // Determine if args changed (new cache entry, not a refetch)
@@ -435,13 +492,15 @@ export function createResourceAccessor(
 
     // When args change and no placeholderData, reset to initial state
     if (isArgChange && !hasPlaceholderData) {
-      Object.assign(state, descriptor.initialState)
+      runInternal(() => Object.assign(state, descriptor.initialState))
     }
 
-    applyPlaceholderData(
-      state as ResourceBaseState<unknown>,
-      queryArg as never,
-      effectiveOptions.placeholderData as PlaceholderData<unknown, unknown> | undefined
+    runInternal(() =>
+      applyPlaceholderData(
+        state as ResourceBaseState<unknown>,
+        queryArg as never,
+        effectiveOptions.placeholderData as PlaceholderData<unknown, unknown> | undefined
+      )
     )
 
     if (descriptor.kind === 'infinite' && mode !== 'restore') {
@@ -492,7 +551,7 @@ export function createResourceAccessor(
       runtime.streamAbortController = undefined
     }
 
-    const currentFetchId = ++runtime.fetchId
+    const requestStartRevision = localBinding?.currentRevision() ?? 0
 
     try {
       let result: unknown
@@ -546,7 +605,7 @@ export function createResourceAccessor(
             }
 
             lastYield = chunk
-            mergeResult(state, chunk)
+            runInternal(() => mergeResult(state, chunk))
           }
         } catch (streamError) {
           if (abortController.signal.aborted) {
@@ -562,6 +621,9 @@ export function createResourceAccessor(
         state.isSuccess = true
         entry.lastFetchedAt = Date.now()
         entry.lastResult = lastYield
+        if (localBinding) {
+          await localBinding.commitRemote(entry, entry.lastFetchedAt, requestStartRevision)
+        }
         updateCachedState(entry, state)
 
         scheduleRefetchInterval()
@@ -570,16 +632,15 @@ export function createResourceAccessor(
 
       // Non-streaming path (original behavior)
       if (descriptor.kind === 'single' || descriptor.kind === 'realtime') {
-        mergeResult(state, result)
+        runInternal(() => mergeResult(state, result))
       } else {
-        mergeResult(state, result, mode === 'append')
+        runInternal(() => mergeResult(state, result, mode === 'append'))
       }
 
       state.isSuccess = true
       entry.hasQueried = true
       entry.lastFetchedAt = Date.now()
       entry.lastResult = result
-      updateCachedState(entry, state)
 
       if (descriptor.kind === 'infinite' && mode !== 'restore') {
         const infiniteHistory = entry.cursorHistory
@@ -591,6 +652,11 @@ export function createResourceAccessor(
           infiniteHistory[infiniteHistory.length - 1] = nextCursor
         }
       }
+
+      if (localBinding) {
+        await localBinding.commitRemote(entry, entry.lastFetchedAt, requestStartRevision)
+      }
+      updateCachedState(entry, state)
 
       if (descriptor.kind === 'realtime') {
         startSubscription()
@@ -604,7 +670,7 @@ export function createResourceAccessor(
         throw error
       }
       state.isError = true
-      state.isSuccess = false
+      state.isSuccess = localBinding && entry.hasQueried ? true : false
       state.error = normalizeError(error)
 
       // Store error in suspense state for ErrorBoundary

--- a/packages/comwit/src/core/query/plugin.ts
+++ b/packages/comwit/src/core/query/plugin.ts
@@ -10,7 +10,6 @@ import type {
   QueryDefaultOptions,
   ResourceDescriptorMap,
 } from './types'
-import type { LocalDefaults } from '../local'
 
 export const QUERY_PLUGIN_NAME = 'query'
 
@@ -28,7 +27,7 @@ export const queryPlugin: FieldPlugin = {
     _defaults?: Record<string, unknown>,
     allDefaults?: Record<string, unknown>
   ): QueryBindingRegistry {
-    return createQueryBindingRegistry(allDefaults?.local as LocalDefaults | undefined)
+    return createQueryBindingRegistry(allDefaults)
   },
 
   bindState(

--- a/packages/comwit/src/core/query/plugin.ts
+++ b/packages/comwit/src/core/query/plugin.ts
@@ -10,6 +10,7 @@ import type {
   QueryDefaultOptions,
   ResourceDescriptorMap,
 } from './types'
+import type { LocalDefaults } from '../local'
 
 export const QUERY_PLUGIN_NAME = 'query'
 
@@ -23,8 +24,11 @@ export const queryPlugin: FieldPlugin = {
     return { initialValue: value.initialState }
   },
 
-  createRegistryState(_defaults?: Record<string, unknown>): QueryBindingRegistry {
-    return createQueryBindingRegistry()
+  createRegistryState(
+    _defaults?: Record<string, unknown>,
+    allDefaults?: Record<string, unknown>
+  ): QueryBindingRegistry {
+    return createQueryBindingRegistry(allDefaults?.local as LocalDefaults | undefined)
   },
 
   bindState(

--- a/packages/comwit/src/core/query/registry.ts
+++ b/packages/comwit/src/core/query/registry.ts
@@ -1,5 +1,4 @@
 import type { QueryBindingRegistry } from './types'
-import { createLocalRegistryState, type LocalDefaults } from '../local'
 
 /**
  * Default time (ms) a cache entry survives after the owning model loses
@@ -7,7 +6,9 @@ import { createLocalRegistryState, type LocalDefaults } from '../local'
  */
 export const DEFAULT_GC_TIME = 5 * 60 * 1000
 
-export function createQueryBindingRegistry(localDefaults?: LocalDefaults): QueryBindingRegistry {
+export function createQueryBindingRegistry(
+  providerDefaults?: Record<string, unknown>
+): QueryBindingRegistry {
   return {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
@@ -15,6 +16,7 @@ export function createQueryBindingRegistry(localDefaults?: LocalDefaults): Query
     selectorLoads: new WeakMap(),
     suspense: new Map(),
     runtimesByModel: new Map(),
-    local: createLocalRegistryState(localDefaults),
+    providerDefaults,
+    services: new Map(),
   }
 }

--- a/packages/comwit/src/core/query/registry.ts
+++ b/packages/comwit/src/core/query/registry.ts
@@ -1,4 +1,5 @@
 import type { QueryBindingRegistry } from './types'
+import { createLocalRegistryState, type LocalDefaults } from '../local'
 
 /**
  * Default time (ms) a cache entry survives after the owning model loses
@@ -6,7 +7,7 @@ import type { QueryBindingRegistry } from './types'
  */
 export const DEFAULT_GC_TIME = 5 * 60 * 1000
 
-export function createQueryBindingRegistry(): QueryBindingRegistry {
+export function createQueryBindingRegistry(localDefaults?: LocalDefaults): QueryBindingRegistry {
   return {
     boundResourceValue: new WeakMap(),
     boundPathProxy: new WeakMap(),
@@ -14,5 +15,6 @@ export function createQueryBindingRegistry(): QueryBindingRegistry {
     selectorLoads: new WeakMap(),
     suspense: new Map(),
     runtimesByModel: new Map(),
+    local: createLocalRegistryState(localDefaults),
   }
 }

--- a/packages/comwit/src/core/query/select.ts
+++ b/packages/comwit/src/core/query/select.ts
@@ -149,7 +149,8 @@ export function createQuerySelectorState<T extends object>(
   loads: QuerySelectorLoad[]
 ): T {
   if (descriptors.size === 0) return state
-  return bindSelectorPath(state, controller, descriptors, registry, loads) as T
+  const target = Object.isFrozen(state) ? { ...state } : state
+  return bindSelectorPath(target, controller, descriptors, registry, loads) as T
 }
 
 export function querySelectorLoadKey(loads: QuerySelectorLoad[]): string {

--- a/packages/comwit/src/core/query/select.ts
+++ b/packages/comwit/src/core/query/select.ts
@@ -1,5 +1,4 @@
-import { serializeQueryArg } from './accessor'
-import { serializeResourceArg } from '../local'
+import { serializeResourceArg } from './accessor'
 import type {
   AnyResourceDescriptor,
   QueryBindingRegistry,
@@ -15,6 +14,7 @@ export type QuerySelectorLoad = {
   hasArg: boolean
   key: QueryCacheKey
   path: string
+  method: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -91,13 +91,14 @@ function createResourceSelector(
 ) {
   return new Proxy(state, {
     get(target, prop, receiver) {
-      if (prop !== 'load') return Reflect.get(target, prop, receiver)
+      const selectorMethod = descriptor.selectorMethod ?? 'load'
+      if (prop !== selectorMethod) return Reflect.get(target, prop, receiver)
 
       return (...args: unknown[]) => {
         const hasArg = args.length > 0
         const arg = hasArg ? args[0] : undefined
-        const key = serializeResourceArg(descriptor, arg, serializeQueryArg)
-        loads.push({ arg, controller, hasArg, key, path })
+        const key = serializeResourceArg(descriptor, arg)
+        loads.push({ arg, controller, hasArg, key, path, method: selectorMethod })
 
         const runtime = registry.boundResourceRuntime.get(controller)
         return cachedState(state, runtime, controller, descriptor, key, registry)
@@ -173,14 +174,14 @@ export function runQuerySelectorLoads(
     }
     if (pending.has(load.key)) continue
 
-    const query = load.controller.query
-    if (typeof query !== 'function') continue
+    const controllerMethod = load.controller[load.method === 'load' ? 'query' : load.method]
+    if (typeof controllerMethod !== 'function') continue
 
     let promise: Promise<unknown>
     try {
       const result = load.hasArg
-        ? query.call(load.controller, load.arg, undefined)
-        : query.call(load.controller)
+        ? controllerMethod.call(load.controller, load.arg, undefined)
+        : controllerMethod.call(load.controller)
       promise = Promise.resolve(result)
     } catch (error) {
       promise = Promise.reject(error)

--- a/packages/comwit/src/core/query/select.ts
+++ b/packages/comwit/src/core/query/select.ts
@@ -1,4 +1,5 @@
 import { serializeQueryArg } from './accessor'
+import { serializeResourceArg } from '../local'
 import type {
   AnyResourceDescriptor,
   QueryBindingRegistry,
@@ -95,7 +96,7 @@ function createResourceSelector(
       return (...args: unknown[]) => {
         const hasArg = args.length > 0
         const arg = hasArg ? args[0] : undefined
-        const key = serializeQueryArg(arg)
+        const key = serializeResourceArg(descriptor, arg, serializeQueryArg)
         loads.push({ arg, controller, hasArg, key, path })
 
         const runtime = registry.boundResourceRuntime.get(controller)

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -392,6 +392,8 @@ export type QueryBindingRegistry = {
   providerDefaults?: Record<string, unknown>
   /** Provider-scoped services shared by lifecycle adapters. */
   services: Map<symbol, unknown>
+  /** Lazily resolves another model from the same provider. */
+  getModelState?: (model: object) => object
 }
 
 export type ResourceRuntimeState = {

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -1,4 +1,6 @@
 export const RESOURCE_BRAND = Symbol('comwit-resource')
+export const RESOURCE_LIFECYCLE = Symbol('comwit-resource-lifecycle')
+export const RESOURCE_TYPE_OVERRIDE = Symbol('comwit-resource-type-override')
 
 export type AsyncResult<T> = T | Promise<T> | AsyncIterable<T>
 
@@ -36,6 +38,8 @@ export type QueryQueryOptions<TData, TArg> = QueryDefaultOptions & {
   placeholderData?: PlaceholderData<TData, TArg>
   force?: boolean
 }
+
+export type ResourceSetOptions<TArg> = [TArg] extends [void] ? { arg?: TArg } : { arg: TArg }
 
 export type ResourceQueryOptions<TData, TArg> = QueryQueryOptions<TData, TArg>
 
@@ -103,6 +107,12 @@ export type BaseResourceDescriptor<TState extends ResourceDataLike, TArg, TResul
     'force'
   >
   queryFn: (arg: TArg, context: ResourceContext<TState>) => AsyncResult<TResult>
+  /** Optional stable cache-key serializer used by resource adapters. */
+  serializeArg?: (arg: TArg) => string
+  /** Selector method name. Ordinary queries expose `load`; adapters may override it. */
+  selectorMethod?: string
+  /** Provider-bound lifecycle adapters. Query itself does not know their implementation. */
+  [RESOURCE_LIFECYCLE]?: ResourceLifecycleFactory[]
   enabled?: (state: any) => boolean
   dependsOn?: (state: any) => any
   refetchInterval?:
@@ -155,7 +165,7 @@ interface ResourceSingleQueryController<TData, TArg> {
   query(arg: TArg, options?: ResourceQueryOptions<TData, TArg>): Promise<unknown>
   query(options?: ResourceQueryOptions<TData, TArg>): Promise<unknown>
   refetch(): Promise<unknown>
-  set(next: unknown): unknown
+  set(next: unknown, options?: ResourceSetOptions<TArg>): unknown
 }
 
 interface ResourceInfiniteQueryController<TData, TArg> extends ResourceSingleQueryController<
@@ -234,8 +244,9 @@ type SuspenseInfiniteResourceState<TData, TArg = unknown> = Omit<
  * trap; at the type level, prefer the standalone `snapshot()` helper for
  * nested slices: `snapshot(state.filter)`.
  */
-export type BoundResourceState<T> =
-  T extends RealtimeResourceDescriptor<infer TData, infer TArg>
+export type BoundResourceState<T> = T extends { [RESOURCE_TYPE_OVERRIDE]: { bound: infer TBound } }
+  ? TBound
+  : T extends RealtimeResourceDescriptor<infer TData, infer TArg>
     ? BoundRealtimeResourceState<TData, TArg>
     : T extends InfiniteResourceDescriptor<infer TData, infer TArg, infer TSuspense>
       ? TSuspense extends true
@@ -264,8 +275,11 @@ export type BoundResourceState<T> =
  * `.load(arg)`, which opts that selector into lifecycle-managed fetching while
  * returning the same query state flags and data shape.
  */
-export type SelectableResourceState<T> =
-  T extends RealtimeResourceDescriptor<infer TData, infer TArg>
+export type SelectableResourceState<T> = T extends {
+  [RESOURCE_TYPE_OVERRIDE]: { selectable: infer TSelectable }
+}
+  ? TSelectable
+  : T extends RealtimeResourceDescriptor<infer TData, infer TArg>
     ? SelectableRealtimeResourceState<TData, TArg>
     : T extends InfiniteResourceDescriptor<infer TData, infer TArg, infer TSuspense>
       ? TSuspense extends true
@@ -352,8 +366,8 @@ export type QueryCacheEntry = {
   lastResult?: unknown
   cursorHistory: Array<string | null>
   state: ResourceDataLike
-  /** Whether the durable local view has already been checked for this key. */
-  localHydrated?: boolean
+  /** Whether lifecycle adapters have already attempted restoration for this key. */
+  resourceHydrated?: boolean
 }
 
 export type SuspenseState = {
@@ -374,8 +388,10 @@ export type QueryBindingRegistry = {
    * belong to a model when its observer count transitions to 0.
    */
   runtimesByModel: Map<symbol, Set<ResourceRuntimeState>>
-  /** Provider-scoped IndexedDB/local collection state. */
-  local?: import('../local').LocalRegistryState
+  /** Provider defaults passed opaquely to resource lifecycle adapters. */
+  providerDefaults?: Record<string, unknown>
+  /** Provider-scoped services shared by lifecycle adapters. */
+  services: Map<symbol, unknown>
 }
 
 export type ResourceRuntimeState = {
@@ -399,4 +415,47 @@ export type ResourceRuntimeState = {
    * back to >=1.
    */
   gcTimers: Map<QueryCacheKey, ReturnType<typeof setTimeout>>
+}
+
+export type ResourceHydratedView = {
+  data: unknown
+  state: Record<string, unknown>
+  fetchedAt: number
+  cursorHistory?: Array<string | null>
+  lastResult?: unknown
+}
+
+export type ResourceLifecycleBindContext = {
+  state: ResourceDataLike
+  descriptor: AnyResourceDescriptor
+  path: string
+  runtime: ResourceRuntimeState
+  registry: QueryBindingRegistry
+}
+
+export type ResourceLifecycleSuccessContext = {
+  entry: QueryCacheEntry
+  fetchedAt: number
+  requestToken: unknown
+}
+
+export type ResourceLifecycleBinding = {
+  activate?(key: QueryCacheKey, arg: unknown): void
+  hydrate?(): Promise<ResourceHydratedView | undefined>
+  beginRequest?(): unknown
+  afterSuccess?(context: ResourceLifecycleSuccessContext): Promise<void> | void
+  runInternal?<T>(callback: () => T): T
+  preserveSuccessOnError?: boolean
+  decorateController?(controller: ResourceDataLike): ResourceDataLike
+}
+
+export type ResourceLifecycleFactory = {
+  bind(context: ResourceLifecycleBindContext): ResourceLifecycleBinding | undefined
+}
+
+export type ResourceTypeOverride<TBound, TSelectable> = {
+  [RESOURCE_TYPE_OVERRIDE]: {
+    bound: TBound
+    selectable: TSelectable
+  }
 }

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -352,6 +352,8 @@ export type QueryCacheEntry = {
   lastResult?: unknown
   cursorHistory: Array<string | null>
   state: ResourceDataLike
+  /** Whether the durable local view has already been checked for this key. */
+  localHydrated?: boolean
 }
 
 export type SuspenseState = {
@@ -372,6 +374,8 @@ export type QueryBindingRegistry = {
    * belong to a model when its observer count transitions to 0.
    */
   runtimesByModel: Map<symbol, Set<ResourceRuntimeState>>
+  /** Provider-scoped IndexedDB/local collection state. */
+  local?: import('../local').LocalRegistryState
 }
 
 export type ResourceRuntimeState = {

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -30,6 +30,8 @@ export type {
   HistoryApi,
   HistoryOptions,
   HistoryConfig,
+  BoundLocalResource,
+  Local,
   LocalCollection,
   LocalCollectionOptions,
   LocalDefaults,
@@ -38,6 +40,10 @@ export type {
   LocalEntityFragment,
   LocalEntityId,
   LocalErrorContext,
+  LocalInfiniteOptions,
+  LocalQueryOptions,
   LocalResourceOptions,
+  LocalStandaloneOptions,
+  SelectableLocalResource,
 } from './core'
 export * from './interceptors'

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -8,6 +8,7 @@ export {
   ComwitProvider,
   keepPreviousData,
   query,
+  local,
   persist,
   computed,
   initDevTools,
@@ -29,5 +30,14 @@ export type {
   HistoryApi,
   HistoryOptions,
   HistoryConfig,
+  LocalCollection,
+  LocalCollectionOptions,
+  LocalDefaults,
+  LocalDataMap,
+  LocalEntity,
+  LocalEntityFragment,
+  LocalEntityId,
+  LocalErrorContext,
+  LocalResourceOptions,
 } from './core'
 export * from './interceptors'

--- a/packages/comwit/src/index.ts
+++ b/packages/comwit/src/index.ts
@@ -43,6 +43,9 @@ export type {
   LocalInfiniteOptions,
   LocalQueryOptions,
   LocalResourceOptions,
+  LocalScope,
+  LocalScopeContext,
+  LocalScopeResolver,
   LocalStandaloneOptions,
   SelectableLocalResource,
 } from './core'

--- a/packages/comwit/tests/local-provider.test.tsx
+++ b/packages/comwit/tests/local-provider.test.tsx
@@ -11,6 +11,56 @@ type Todo = {
 }
 
 describe('local() provider integration', () => {
+  test('resolves an inline collection scope from another model lazily', async () => {
+    const factory = new IDBFactory()
+    const database = `local-provider-model-scope-${crypto.randomUUID()}`
+    const identityModel = model({ me: { id: '1' } as { id: string } | null })
+    let scopeEvaluations = 0
+    const todos = local.collection<Todo>({
+      key: 'model-scoped-todos',
+      version: 1,
+      scope: ({ state }) => {
+        scopeEvaluations++
+        const id = state(identityModel).me?.id
+        return id ? `user:${id}` : null
+      },
+    })
+    const queryFn = vi.fn().mockResolvedValue([{ id: '1', title: 'Scoped' }])
+    const todoModel = model({
+      list: local.query<Todo[]>({
+        source: todos,
+        initialData: [],
+        staleTime: 60_000,
+        queryFn,
+      }),
+    })
+
+    expect(scopeEvaluations).toBe(0)
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <ComwitProvider defaultOptions={{ local: { database, indexedDB: factory } }}>
+          {children}
+        </ComwitProvider>
+      )
+    }
+
+    const first = renderHook(() => useModel(todoModel, (state) => state.list.load()), {
+      wrapper: Wrapper,
+    })
+    await waitFor(() => expect(first.result.current.data[0]?.title).toBe('Scoped'))
+    first.unmount()
+
+    const second = renderHook(() => useModel(todoModel, (state) => state.list.load()), {
+      wrapper: Wrapper,
+    })
+    await waitFor(() => expect(second.result.current.data[0]?.title).toBe('Scoped'))
+
+    expect(scopeEvaluations).toBeGreaterThan(0)
+    expect(queryFn).toHaveBeenCalledOnce()
+    second.unmount()
+  })
+
   test('uses defaultOptions.local for selector-owned loads across provider instances', async () => {
     const factory = new IDBFactory()
     const database = `local-provider-${crypto.randomUUID()}`

--- a/packages/comwit/tests/local-provider.test.tsx
+++ b/packages/comwit/tests/local-provider.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import React, { type ReactNode } from 'react'
+import { IDBFactory } from 'fake-indexeddb'
+import { renderHook, waitFor } from '@testing-library/react'
+import { ComwitProvider, local, model, query, useModel } from '../src'
+
+type Todo = {
+  id: string
+  title: string
+}
+
+describe('local() provider integration', () => {
+  test('uses defaultOptions.local for selector-owned loads across provider instances', async () => {
+    const factory = new IDBFactory()
+    const database = `local-provider-${crypto.randomUUID()}`
+    const todos = local.collection<Todo>({ key: 'todos', version: 1 })
+    const queryFn = vi.fn().mockResolvedValue([{ id: '1', title: 'Durable' }])
+    const todoModel = model({
+      list: local(
+        query<Todo[], { status: string }>({
+          initialData: [],
+          staleTime: 60_000,
+          queryFn,
+        }),
+        { source: todos }
+      ),
+    })
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <ComwitProvider
+          defaultOptions={{
+            local: {
+              database,
+              scope: 'user:1',
+              indexedDB: factory,
+            },
+          }}
+        >
+          {children}
+        </ComwitProvider>
+      )
+    }
+
+    const first = renderHook(
+      () => useModel(todoModel, (state) => state.list.load({ status: 'open' })),
+      { wrapper: Wrapper }
+    )
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true))
+    first.unmount()
+
+    const second = renderHook(
+      () => useModel(todoModel, (state) => state.list.load({ status: 'open' })),
+      { wrapper: Wrapper }
+    )
+    await waitFor(() => expect(second.result.current.data[0]?.title).toBe('Durable'))
+
+    expect(queryFn).toHaveBeenCalledOnce()
+    second.unmount()
+  })
+})

--- a/packages/comwit/tests/local-provider.test.tsx
+++ b/packages/comwit/tests/local-provider.test.tsx
@@ -2,7 +2,8 @@
 import React, { type ReactNode } from 'react'
 import { IDBFactory } from 'fake-indexeddb'
 import { renderHook, waitFor } from '@testing-library/react'
-import { ComwitProvider, local, model, query, useModel } from '../src'
+import { ComwitProvider, local, model, useModel } from '../src'
+import { bindResourceState, createQueryBindingRegistry } from '../src/core/query'
 
 type Todo = {
   id: string
@@ -16,14 +17,12 @@ describe('local() provider integration', () => {
     const todos = local.collection<Todo>({ key: 'todos', version: 1 })
     const queryFn = vi.fn().mockResolvedValue([{ id: '1', title: 'Durable' }])
     const todoModel = model({
-      list: local(
-        query<Todo[], { status: string }>({
-          initialData: [],
-          staleTime: 60_000,
-          queryFn,
-        }),
-        { source: todos }
-      ),
+      list: local.query<Todo[], { status: string }>({
+        source: todos,
+        initialData: [],
+        staleTime: 60_000,
+        queryFn,
+      }),
     })
 
     function Wrapper({ children }: { children: ReactNode }) {
@@ -57,5 +56,56 @@ describe('local() provider integration', () => {
 
     expect(queryFn).toHaveBeenCalledOnce()
     second.unmount()
+  })
+
+  test('lets a server Suspense fallback restore only IndexedDB detail data', async () => {
+    const factory = new IDBFactory()
+    const database = `local-provider-detail-${crypto.randomUUID()}`
+    const todos = local.collection<Todo>({ key: 'todos', version: 1 })
+    const todoModel = model({
+      detail: local<Todo | null, string>({
+        source: todos,
+        initialData: null,
+      }),
+    })
+
+    const seedStore = todoModel.instance()
+    const seed = bindResourceState(
+      seedStore.proxy,
+      todoModel.pluginBags.get('query')!,
+      undefined,
+      createQueryBindingRegistry({
+        local: { database, scope: 'user:1', indexedDB: factory },
+      }),
+      todoModel.key
+    ) as any
+    seed.detail.set({ id: '1', title: 'Cached SEO detail' }, { arg: '1' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <ComwitProvider
+          defaultOptions={{
+            local: { database, scope: 'user:1', indexedDB: factory },
+          }}
+        >
+          {children}
+        </ComwitProvider>
+      )
+    }
+
+    const cached = renderHook(() => useModel(todoModel, (state) => state.detail.restore('1')), {
+      wrapper: Wrapper,
+    })
+    expect(cached.result.current.data).toBeNull()
+    await waitFor(() => expect(cached.result.current.data?.title).toBe('Cached SEO detail'))
+    cached.unmount()
+
+    const miss = renderHook(() => useModel(todoModel, (state) => state.detail.restore('missing')), {
+      wrapper: Wrapper,
+    })
+    await waitFor(() => expect(miss.result.current.isLoading).toBe(false))
+    expect(miss.result.current.data).toBeNull()
+    miss.unmount()
   })
 })

--- a/packages/comwit/tests/local.test.ts
+++ b/packages/comwit/tests/local.test.ts
@@ -1,5 +1,5 @@
 import { IDBFactory } from 'fake-indexeddb'
-import { local, model, query } from '../src/core'
+import { local, model, query, silent } from '../src/core'
 import { bindResourceState, createQueryBindingRegistry } from '../src/core/query'
 
 type TodoEntity = {
@@ -34,29 +34,27 @@ function createTodoBound(options: {
   onError?: (error: unknown) => void
 }) {
   const todoModel = model({
-    list: local(
-      query<TodoListItem[], { status: 'open' | 'done' }>({
-        initialData: [],
-        staleTime: options.staleTime,
-        queryFn: options.listFn ?? (() => []),
-      }),
-      { source: options.source }
-    ),
-    detail: local(
-      query<TodoDetail | null, string>({
-        initialData: null,
-        staleTime: options.staleTime,
-        queryFn: options.detailFn ?? (() => null),
-      }),
-      { source: options.source }
-    ),
+    list: local.query<TodoListItem[], { status: 'open' | 'done' }>({
+      source: options.source,
+      initialData: [],
+      staleTime: options.staleTime,
+      queryFn: options.listFn ?? (() => []),
+    }),
+    detail: local.query<TodoDetail | null, string>({
+      source: options.source,
+      initialData: null,
+      staleTime: options.staleTime,
+      queryFn: options.detailFn ?? (() => null),
+    }),
   })
   const store = todoModel.instance()
   const registry = createQueryBindingRegistry({
-    indexedDB: options.factory,
-    database: options.database,
-    scope: options.scope,
-    onError: options.onError ? (error) => options.onError?.(error) : undefined,
+    local: {
+      indexedDB: options.factory,
+      database: options.database,
+      scope: options.scope,
+      onError: options.onError ? (error) => options.onError?.(error) : undefined,
+    },
   })
   const bound = bindResourceState(
     store.proxy,
@@ -75,6 +73,127 @@ describe('local()', () => {
     expect(() => local.collection<TodoEntity>({ key: 'todos', version: 0 })).toThrow(
       'positive integer'
     )
+
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const legacy = local(query<TodoListItem[]>({ initialData: [], queryFn: () => [] }), {
+      source,
+    })
+    expect(legacy.kind).toBe('single')
+  })
+
+  test('restores a standalone detail seeded by server initialization without an API query', async () => {
+    const factory = new IDBFactory()
+    const database = `local-standalone-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+
+    const createBound = () => {
+      const todoModel = model({
+        list: local.query<TodoListItem[], { status: 'open' | 'done' }>({
+          source,
+          initialData: [],
+          staleTime: 60_000,
+          queryFn: () => [{ id: '1', title: 'List title', status: 'open', updatedAt: 1 }],
+        }),
+        detail: local<TodoDetail | null, string>({
+          source,
+          initialData: null,
+        }),
+      })
+      const store = todoModel.instance()
+      const registry = createQueryBindingRegistry({
+        local: { indexedDB: factory, database },
+      })
+      return bindResourceState(
+        store.proxy,
+        todoModel.pluginBags.get('query')!,
+        undefined,
+        registry,
+        todoModel.key
+      ) as any
+    }
+
+    const first = createBound()
+    await first.list.query({ status: 'open' })
+
+    silent(() => {
+      first.detail.set(
+        {
+          id: '1',
+          title: 'Server detail',
+          status: 'open',
+          updatedAt: 2,
+          description: 'SEO response',
+        },
+        { arg: '1' }
+      )
+    })
+
+    await vi.waitFor(() => expect(first.list.data[0].title).toBe('Server detail'))
+
+    const restored = createBound()
+    await restored.detail.restore('1')
+
+    expect(restored.detail.data).toEqual({
+      id: '1',
+      title: 'Server detail',
+      status: 'open',
+      updatedAt: 2,
+      description: 'SEO response',
+    })
+    expect(restored.detail.isSuccess).toBe(true)
+
+    restored.detail.remove('1')
+    expect(restored.detail.data).toBeNull()
+  })
+
+  test('lets a server initializer win over a pending standalone IndexedDB restore', async () => {
+    const factory = new IDBFactory()
+    const database = `local-standalone-race-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+
+    const createBound = () => {
+      const todoModel = model({
+        detail: local<TodoDetail | null, string>({ source, initialData: null }),
+      })
+      const store = todoModel.instance()
+      return bindResourceState(
+        store.proxy,
+        todoModel.pluginBags.get('query')!,
+        undefined,
+        createQueryBindingRegistry({ local: { indexedDB: factory, database } }),
+        todoModel.key
+      ) as any
+    }
+
+    const seed = createBound()
+    seed.detail.set(
+      {
+        id: '1',
+        title: 'IndexedDB value',
+        status: 'open',
+        updatedAt: 1,
+        description: 'Old',
+      },
+      { arg: '1' }
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const next = createBound()
+    const restoring = next.detail.restore('1')
+    next.detail.set(
+      {
+        id: '1',
+        title: 'Server value',
+        status: 'open',
+        updatedAt: 2,
+        description: 'Fresh',
+      },
+      { arg: '1' }
+    )
+    await restoring
+
+    expect(next.detail.data.title).toBe('Server value')
+    expect(next.detail.data.description).toBe('Fresh')
   })
 
   test('hydrates an exact list argument from IndexedDB without refetching while fresh', async () => {
@@ -383,29 +502,29 @@ describe('local()', () => {
 
     const createPageBound = (listFn: () => Promise<TodoPage> | TodoPage, detailFn: () => any) => {
       const pageModel = model({
-        page: local(
-          query<TodoPage>({
-            initialData: { items: [], total: 0 },
-            staleTime: 60_000,
-            queryFn: listFn,
-          }),
-          {
-            source,
-            map: {
-              split: (page) => ({ rows: page.items, meta: { total: page.total } }),
-              join: (rows, meta) => ({
-                items: rows,
-                total: meta?.total ?? 0,
-              }),
-            },
-          }
-        ),
-        detail: local(query<TodoDetail | null, string>({ initialData: null, queryFn: detailFn }), {
+        page: local.query<TodoPage>({
           source,
+          initialData: { items: [], total: 0 },
+          staleTime: 60_000,
+          queryFn: listFn,
+          map: {
+            split: (page) => ({ rows: page.items, meta: { total: page.total } }),
+            join: (rows, meta) => ({
+              items: rows,
+              total: meta?.total ?? 0,
+            }),
+          },
+        }),
+        detail: local.query<TodoDetail | null, string>({
+          source,
+          initialData: null,
+          queryFn: detailFn,
         }),
       })
       const store = pageModel.instance()
-      const registry = createQueryBindingRegistry({ indexedDB: factory, database })
+      const registry = createQueryBindingRegistry({
+        local: { indexedDB: factory, database },
+      })
       return bindResourceState(
         store.proxy,
         pageModel.pluginBags.get('query')!,
@@ -452,17 +571,17 @@ describe('local()', () => {
 
     const createFeed = (queryFn: () => any) => {
       const feedModel = model({
-        feed: local(
-          query.infinite<TodoListItem[]>({
-            initialData: [],
-            staleTime: 60_000,
-            queryFn,
-          }),
-          { source }
-        ),
+        feed: local.infinite<TodoListItem[]>({
+          source,
+          initialData: [],
+          staleTime: 60_000,
+          queryFn,
+        }),
       })
       const store = feedModel.instance()
-      const registry = createQueryBindingRegistry({ indexedDB: factory, database })
+      const registry = createQueryBindingRegistry({
+        local: { indexedDB: factory, database },
+      })
       return bindResourceState(
         store.proxy,
         feedModel.pluginBags.get('query')!,

--- a/packages/comwit/tests/local.test.ts
+++ b/packages/comwit/tests/local.test.ts
@@ -1,0 +1,491 @@
+import { IDBFactory } from 'fake-indexeddb'
+import { local, model, query } from '../src/core'
+import { bindResourceState, createQueryBindingRegistry } from '../src/core/query'
+
+type TodoEntity = {
+  id: string
+  title: string
+  status: 'open' | 'done'
+  updatedAt: number
+  description?: string
+}
+
+type TodoListItem = Pick<TodoEntity, 'id' | 'title' | 'status' | 'updatedAt'>
+type TodoDetail = TodoEntity & { description: string }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function createTodoBound(options: {
+  factory: IDBFactory
+  database: string
+  source: ReturnType<typeof local.collection<TodoEntity>>
+  listFn?: (filter: { status: 'open' | 'done' }) => Promise<TodoListItem[]> | TodoListItem[]
+  detailFn?: (id: string) => Promise<TodoDetail | null> | TodoDetail | null
+  staleTime?: number
+  scope?: string
+  onError?: (error: unknown) => void
+}) {
+  const todoModel = model({
+    list: local(
+      query<TodoListItem[], { status: 'open' | 'done' }>({
+        initialData: [],
+        staleTime: options.staleTime,
+        queryFn: options.listFn ?? (() => []),
+      }),
+      { source: options.source }
+    ),
+    detail: local(
+      query<TodoDetail | null, string>({
+        initialData: null,
+        staleTime: options.staleTime,
+        queryFn: options.detailFn ?? (() => null),
+      }),
+      { source: options.source }
+    ),
+  })
+  const store = todoModel.instance()
+  const registry = createQueryBindingRegistry({
+    indexedDB: options.factory,
+    database: options.database,
+    scope: options.scope,
+    onError: options.onError ? (error) => options.onError?.(error) : undefined,
+  })
+  const bound = bindResourceState(
+    store.proxy,
+    todoModel.pluginBags.get('query')!,
+    undefined,
+    registry,
+    todoModel.key
+  ) as any
+
+  return { bound, registry }
+}
+
+describe('local()', () => {
+  test('requires explicit stable collection identity and version', () => {
+    expect(() => local.collection<TodoEntity>({ key: '', version: 1 })).toThrow('non-empty key')
+    expect(() => local.collection<TodoEntity>({ key: 'todos', version: 0 })).toThrow(
+      'positive integer'
+    )
+  })
+
+  test('hydrates an exact list argument from IndexedDB without refetching while fresh', async () => {
+    const factory = new IDBFactory()
+    const database = `local-hydrate-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const firstQuery = vi.fn(() => [
+      { id: '1', title: 'Cached', status: 'open' as const, updatedAt: 1 },
+    ])
+    const first = createTodoBound({
+      factory,
+      database,
+      source,
+      listFn: firstQuery,
+      staleTime: 60_000,
+    })
+
+    await first.bound.list.query({ status: 'open' })
+    expect(firstQuery).toHaveBeenCalledOnce()
+
+    const secondQuery = vi.fn(() => [
+      { id: '1', title: 'Server', status: 'open' as const, updatedAt: 2 },
+    ])
+    const second = createTodoBound({
+      factory,
+      database,
+      source,
+      listFn: secondQuery,
+      staleTime: 60_000,
+    })
+
+    await second.bound.list.query({ status: 'open' })
+
+    expect(second.bound.list.data).toEqual([
+      { id: '1', title: 'Cached', status: 'open', updatedAt: 1 },
+    ])
+    expect(second.bound.list.isSuccess).toBe(true)
+    expect(secondQuery).not.toHaveBeenCalled()
+
+    await second.bound.list.query({ status: 'done' })
+    expect(secondQuery).toHaveBeenCalledOnce()
+  })
+
+  test('shows a stale durable snapshot while revalidating and atomically replaces it', async () => {
+    const factory = new IDBFactory()
+    const database = `local-revalidate-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const seed = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn: () => [{ id: '1', title: 'Cached', status: 'open', updatedAt: 1 }],
+    })
+    await seed.bound.list.query({ status: 'open' })
+
+    const request = deferred<TodoListItem[]>()
+    const queryFn = vi.fn(() => request.promise)
+    const next = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn: queryFn,
+    })
+
+    const promise = next.bound.list.query({ status: 'open' })
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledOnce())
+
+    expect(next.bound.list.data[0].title).toBe('Cached')
+    expect(next.bound.list.isLoading).toBe(false)
+    expect(next.bound.list.isFetching).toBe(true)
+
+    request.resolve([{ id: '1', title: 'Fresh', status: 'open', updatedAt: 2 }])
+    await promise
+
+    expect(next.bound.list.data[0].title).toBe('Fresh')
+    expect(next.bound.list.isFetching).toBe(false)
+  })
+
+  test('shares canonical fields between list and detail without dropping detail-only fields', async () => {
+    const factory = new IDBFactory()
+    const database = `local-list-detail-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const listFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: '1', title: 'List title', status: 'open', updatedAt: 1 }])
+      .mockResolvedValueOnce([{ id: '1', title: 'List refreshed', status: 'open', updatedAt: 3 }])
+      .mockResolvedValueOnce([])
+    const detailFn = vi.fn().mockResolvedValue({
+      id: '1',
+      title: 'Detail title',
+      status: 'open',
+      updatedAt: 2,
+      description: 'Only the detail endpoint knows this',
+    })
+    const { bound } = createTodoBound({
+      factory,
+      database,
+      source,
+      listFn,
+      detailFn,
+      staleTime: 0,
+    })
+
+    await bound.list.query({ status: 'open' })
+    await bound.detail.query('1')
+
+    expect(bound.list.data[0].title).toBe('Detail title')
+    expect(bound.detail.data.description).toBe('Only the detail endpoint knows this')
+
+    await bound.list.refetch()
+
+    expect(bound.detail.data.title).toBe('List refreshed')
+    expect(bound.detail.data.description).toBe('Only the detail endpoint knows this')
+
+    await bound.list.refetch()
+
+    expect(bound.list.data).toEqual([])
+    expect(bound.detail.data.title).toBe('List refreshed')
+    expect(bound.detail.data.description).toBe('Only the detail endpoint knows this')
+  })
+
+  test('fans an optimistic entity edit out to loaded views and persists it', async () => {
+    const factory = new IDBFactory()
+    const database = `local-optimistic-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const first = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 60_000,
+      listFn: () => [{ id: '1', title: 'Before', status: 'open', updatedAt: 1 }],
+      detailFn: () => ({
+        id: '1',
+        title: 'Before',
+        status: 'open',
+        updatedAt: 1,
+        description: 'Detail',
+      }),
+    })
+    await first.bound.list.query({ status: 'open' })
+    await first.bound.detail.query('1')
+
+    first.bound.detail.data.title = 'Optimistic'
+    await vi.waitFor(() => expect(first.bound.list.data[0].title).toBe('Optimistic'))
+
+    const secondQuery = vi.fn(() => [])
+    const second = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 60_000,
+      listFn: secondQuery,
+    })
+    await second.bound.list.query({ status: 'open' })
+
+    expect(second.bound.list.data[0].title).toBe('Optimistic')
+    expect(secondQuery).not.toHaveBeenCalled()
+  })
+
+  test('does not let an older in-flight response overwrite a newer local edit', async () => {
+    const factory = new IDBFactory()
+    const database = `local-race-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const request = deferred<TodoListItem[]>()
+    const listFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: '1', title: 'Before', status: 'open', updatedAt: 1 }])
+      .mockReturnValueOnce(request.promise)
+    const { bound } = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn,
+    })
+
+    await bound.list.query({ status: 'open' })
+    const refetch = bound.list.refetch()
+    bound.list.data[0].title = 'Optimistic'
+    await Promise.resolve()
+
+    request.resolve([{ id: '1', title: 'Old server value', status: 'open', updatedAt: 1 }])
+    await refetch
+
+    expect(bound.list.data[0].title).toBe('Optimistic')
+  })
+
+  test('does not let an older in-flight response restore locally removed membership', async () => {
+    const factory = new IDBFactory()
+    const database = `local-membership-race-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const request = deferred<TodoListItem[]>()
+    const listFn = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: '1', title: 'Before', status: 'open', updatedAt: 1 }])
+      .mockReturnValueOnce(request.promise)
+    const first = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn,
+    })
+
+    await first.bound.list.query({ status: 'open' })
+    const refetch = first.bound.list.refetch()
+    first.bound.list.data.splice(0, 1)
+    await Promise.resolve()
+
+    request.resolve([{ id: '1', title: 'Old server value', status: 'open', updatedAt: 1 }])
+    await refetch
+
+    expect(first.bound.list.data).toEqual([])
+
+    const restoreQuery = vi.fn(() => [
+      { id: '1', title: 'Server', status: 'open' as const, updatedAt: 2 },
+    ])
+    const restored = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 60_000,
+      listFn: restoreQuery,
+    })
+    await restored.bound.list.query({ status: 'open' })
+
+    expect(restored.bound.list.data).toEqual([])
+    expect(restoreQuery).not.toHaveBeenCalled()
+  })
+
+  test('retains hydrated data when background revalidation fails', async () => {
+    const factory = new IDBFactory()
+    const database = `local-error-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const seed = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn: () => [{ id: '1', title: 'Cached', status: 'open', updatedAt: 1 }],
+    })
+    await seed.bound.list.query({ status: 'open' })
+
+    const next = createTodoBound({
+      factory,
+      database,
+      source,
+      staleTime: 0,
+      listFn: () => Promise.reject(new Error('Offline')),
+    })
+
+    await expect(next.bound.list.query({ status: 'open' })).rejects.toThrow('Offline')
+    expect(next.bound.list.data[0].title).toBe('Cached')
+    expect(next.bound.list.isSuccess).toBe(true)
+    expect(next.bound.list.isError).toBe(true)
+  })
+
+  test('treats a collection version change and provider scope change as cache misses', async () => {
+    const factory = new IDBFactory()
+    const database = `local-version-scope-${crypto.randomUUID()}`
+    const v1 = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const seed = createTodoBound({
+      factory,
+      database,
+      source: v1,
+      scope: 'user:1',
+      staleTime: 60_000,
+      listFn: () => [{ id: '1', title: 'V1', status: 'open', updatedAt: 1 }],
+    })
+    await seed.bound.list.query({ status: 'open' })
+
+    const v2Query = vi.fn(() => [{ id: '1', title: 'V2', status: 'open' as const, updatedAt: 2 }])
+    const v2 = createTodoBound({
+      factory,
+      database,
+      source: local.collection<TodoEntity>({ key: 'todos', version: 2 }),
+      scope: 'user:1',
+      staleTime: 60_000,
+      listFn: v2Query,
+    })
+    await v2.bound.list.query({ status: 'open' })
+    expect(v2Query).toHaveBeenCalledOnce()
+
+    const otherUserQuery = vi.fn(() => [
+      { id: '1', title: 'Other user', status: 'open' as const, updatedAt: 1 },
+    ])
+    const otherUser = createTodoBound({
+      factory,
+      database,
+      source: v1,
+      scope: 'user:2',
+      staleTime: 60_000,
+      listFn: otherUserQuery,
+    })
+    await otherUser.bound.list.query({ status: 'open' })
+    expect(otherUserQuery).toHaveBeenCalledOnce()
+  })
+
+  test('normalizes and restores response envelopes with map.split/join', async () => {
+    const factory = new IDBFactory()
+    const database = `local-envelope-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    type TodoPage = { items: TodoListItem[]; total: number }
+
+    const createPageBound = (listFn: () => Promise<TodoPage> | TodoPage, detailFn: () => any) => {
+      const pageModel = model({
+        page: local(
+          query<TodoPage>({
+            initialData: { items: [], total: 0 },
+            staleTime: 60_000,
+            queryFn: listFn,
+          }),
+          {
+            source,
+            map: {
+              split: (page) => ({ rows: page.items, meta: { total: page.total } }),
+              join: (rows, meta) => ({
+                items: rows,
+                total: meta?.total ?? 0,
+              }),
+            },
+          }
+        ),
+        detail: local(query<TodoDetail | null, string>({ initialData: null, queryFn: detailFn }), {
+          source,
+        }),
+      })
+      const store = pageModel.instance()
+      const registry = createQueryBindingRegistry({ indexedDB: factory, database })
+      return bindResourceState(
+        store.proxy,
+        pageModel.pluginBags.get('query')!,
+        undefined,
+        registry,
+        pageModel.key
+      ) as any
+    }
+
+    const first = createPageBound(
+      () => ({
+        items: [{ id: '1', title: 'Summary', status: 'open', updatedAt: 1 }],
+        total: 42,
+      }),
+      () => ({
+        id: '1',
+        title: 'Detail title',
+        status: 'open',
+        updatedAt: 2,
+        description: 'Detail',
+      })
+    )
+    await first.page.query()
+    await first.detail.query('1')
+
+    expect(first.page.data).toEqual({
+      items: [expect.objectContaining({ id: '1', title: 'Detail title' })],
+      total: 42,
+    })
+
+    const queryFn = vi.fn()
+    const second = createPageBound(queryFn, () => null)
+    await second.page.query()
+
+    expect(second.page.data.items[0].title).toBe('Detail title')
+    expect(second.page.data.total).toBe(42)
+    expect(queryFn).not.toHaveBeenCalled()
+  })
+
+  test('restores infinite data and cursor metadata from a durable view', async () => {
+    const factory = new IDBFactory()
+    const database = `local-infinite-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+
+    const createFeed = (queryFn: () => any) => {
+      const feedModel = model({
+        feed: local(
+          query.infinite<TodoListItem[]>({
+            initialData: [],
+            staleTime: 60_000,
+            queryFn,
+          }),
+          { source }
+        ),
+      })
+      const store = feedModel.instance()
+      const registry = createQueryBindingRegistry({ indexedDB: factory, database })
+      return bindResourceState(
+        store.proxy,
+        feedModel.pluginBags.get('query')!,
+        undefined,
+        registry,
+        feedModel.key
+      ) as any
+    }
+
+    const first = createFeed(() => ({
+      data: [{ id: '1', title: 'Page one', status: 'open', updatedAt: 1 }],
+      cursor: 'next',
+      hasMore: true,
+    }))
+    await first.feed.query()
+
+    const secondQuery = vi.fn()
+    const second = createFeed(secondQuery)
+    await second.feed.query()
+
+    expect(second.feed.data[0].title).toBe('Page one')
+    expect(second.feed.cursor).toBe('next')
+    expect(second.feed.hasMore).toBe(true)
+    expect(secondQuery).not.toHaveBeenCalled()
+  })
+})

--- a/packages/comwit/tests/local.test.ts
+++ b/packages/comwit/tests/local.test.ts
@@ -75,10 +75,90 @@ describe('local()', () => {
     )
 
     const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    expect(source.getId({ id: '1', title: 'Todo', status: 'open', updatedAt: 1 })).toBe('1')
     const legacy = local(query<TodoListItem[]>({ initialData: [], queryFn: () => [] }), {
       source,
     })
     expect(legacy.kind).toBe('single')
+  })
+
+  test('skips IndexedDB on the server and continues as an ordinary query', async () => {
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const queryFn = vi.fn(() => [
+      { id: '1', title: 'Server only', status: 'open' as const, updatedAt: 1 },
+    ])
+    const todoModel = model({
+      list: local.query<TodoListItem[]>({ source, initialData: [], queryFn }),
+    })
+    const store = todoModel.instance()
+    const bound = bindResourceState(
+      store.proxy,
+      todoModel.pluginBags.get('query')!,
+      undefined,
+      createQueryBindingRegistry(),
+      todoModel.key
+    ) as any
+
+    await bound.list.query()
+
+    expect(queryFn).toHaveBeenCalledOnce()
+    expect(bound.list.data[0].title).toBe('Server only')
+    expect(bound.list.isSuccess).toBe(true)
+    expect(bound.list.isError).toBe(false)
+  })
+
+  test('normalizes, fans out, and restores entities with a custom getId', async () => {
+    type ExternalTodo = {
+      uuid: string
+      title: string
+      description?: string
+    }
+
+    const factory = new IDBFactory()
+    const database = `local-custom-id-${crypto.randomUUID()}`
+    const source = local.collection<ExternalTodo>({
+      key: 'external-todos',
+      version: 1,
+      getId: (todo) => todo.uuid,
+    })
+
+    const createBound = () => {
+      const todoModel = model({
+        list: local.query<ExternalTodo[]>({
+          source,
+          initialData: [],
+          queryFn: () => [{ uuid: 'todo-1', title: 'List title' }],
+          staleTime: 60_000,
+        }),
+        detail: local<ExternalTodo | null, string>({ source, initialData: null }),
+      })
+      const store = todoModel.instance()
+      return bindResourceState(
+        store.proxy,
+        todoModel.pluginBags.get('query')!,
+        undefined,
+        createQueryBindingRegistry({ local: { indexedDB: factory, database } }),
+        todoModel.key
+      ) as any
+    }
+
+    const first = createBound()
+    await first.list.query()
+    first.detail.set(
+      { uuid: 'todo-1', title: 'Detail title', description: 'Custom identity' },
+      { arg: 'todo-1' }
+    )
+
+    await vi.waitFor(() => expect(first.list.data[0].title).toBe('Detail title'))
+
+    const restored = createBound()
+    await restored.detail.restore('todo-1')
+
+    expect(restored.detail.data).toEqual({
+      uuid: 'todo-1',
+      title: 'Detail title',
+      description: 'Custom identity',
+    })
   })
 
   test('restores a standalone detail seeded by server initialization without an API query', async () => {

--- a/packages/comwit/tests/local.test.ts
+++ b/packages/comwit/tests/local.test.ts
@@ -73,6 +73,9 @@ describe('local()', () => {
     expect(() => local.collection<TodoEntity>({ key: 'todos', version: 0 })).toThrow(
       'positive integer'
     )
+    expect(() => local.collection<TodoEntity>({ key: 'todos', version: 1, scope: ' ' })).toThrow(
+      'scope must be non-empty'
+    )
 
     const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
     expect(source.getId({ id: '1', title: 'Todo', status: 'open', updatedAt: 1 })).toBe('1')
@@ -572,6 +575,197 @@ describe('local()', () => {
     })
     await otherUser.bound.list.query({ status: 'open' })
     expect(otherUserQuery).toHaveBeenCalledOnce()
+  })
+
+  test('lets a collection override provider scope for shared public data', async () => {
+    const factory = new IDBFactory()
+    const database = `local-public-scope-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({
+      key: 'public-todos',
+      version: 1,
+      scope: 'public',
+    })
+    const seedQuery = vi.fn(() => [
+      { id: '1', title: 'Shared', status: 'open' as const, updatedAt: 1 },
+    ])
+    const seed = createTodoBound({
+      factory,
+      database,
+      source,
+      scope: 'user:1',
+      staleTime: 60_000,
+      listFn: seedQuery,
+    })
+    await seed.bound.list.query({ status: 'open' })
+
+    const restoreQuery = vi.fn(() => [
+      { id: '1', title: 'Remote', status: 'open' as const, updatedAt: 2 },
+    ])
+    const restored = createTodoBound({
+      factory,
+      database,
+      source,
+      scope: 'user:2',
+      staleTime: 60_000,
+      listFn: restoreQuery,
+    })
+    await restored.bound.list.query({ status: 'open' })
+
+    expect(seedQuery).toHaveBeenCalledOnce()
+    expect(restoreQuery).not.toHaveBeenCalled()
+    expect(restored.bound.list.data[0].title).toBe('Shared')
+  })
+
+  test('resolves collection scope lazily from another provider-bound model', async () => {
+    const factory = new IDBFactory()
+    const database = `local-model-scope-${crypto.randomUUID()}`
+    const identityModel = model<{ me: { id: string } | null }>({ me: null })
+    let scopeEvaluations = 0
+    const source = local.collection<TodoEntity>({
+      key: 'model-scoped-todos',
+      version: 1,
+      scope: ({ state }) => {
+        scopeEvaluations++
+        const id = state(identityModel).me?.id
+        return id ? `user:${id}` : null
+      },
+    })
+
+    expect(scopeEvaluations).toBe(0)
+
+    const createBound = (userId: string | null, listFn: () => TodoListItem[]) => {
+      const identityStore = identityModel.instance()
+      identityStore.proxy.me = userId ? { id: userId } : null
+      const todoModel = model({
+        list: local.query<TodoListItem[]>({
+          source,
+          initialData: [],
+          staleTime: 60_000,
+          queryFn: listFn,
+        }),
+      })
+      const store = todoModel.instance()
+      const registry = createQueryBindingRegistry({
+        local: { indexedDB: factory, database, scope: 'provider-default' },
+      })
+      registry.getModelState = (sourceModel) => {
+        if (sourceModel !== identityModel) throw new Error('Unexpected scope model')
+        return identityStore.proxy
+      }
+      const bound = bindResourceState(
+        store.proxy,
+        todoModel.pluginBags.get('query')!,
+        undefined,
+        registry,
+        todoModel.key
+      ) as any
+      return bound
+    }
+
+    const unresolvedQuery = vi.fn(() => [
+      { id: '1', title: 'Unscoped', status: 'open' as const, updatedAt: 1 },
+    ])
+    await createBound(null, unresolvedQuery).list.query()
+    expect(unresolvedQuery).toHaveBeenCalledOnce()
+    expect(scopeEvaluations).toBeGreaterThan(0)
+
+    const seedQuery = vi.fn(() => [
+      { id: '1', title: 'User one', status: 'open' as const, updatedAt: 2 },
+    ])
+    await createBound('1', seedQuery).list.query()
+
+    const restoreQuery = vi.fn(() => [
+      { id: '1', title: 'Remote one', status: 'open' as const, updatedAt: 3 },
+    ])
+    const restored = createBound('1', restoreQuery)
+    await restored.list.query()
+    expect(restoreQuery).not.toHaveBeenCalled()
+    expect(restored.list.data[0].title).toBe('User one')
+
+    const userTwoQuery = vi.fn(() => [
+      { id: '1', title: 'User two', status: 'open' as const, updatedAt: 1 },
+    ])
+    const userTwo = createBound('2', userTwoQuery)
+    await userTwo.list.query()
+    expect(userTwoQuery).toHaveBeenCalledOnce()
+    expect(userTwo.list.data[0].title).toBe('User two')
+  })
+
+  test('drops an in-flight result when its model-derived scope changes', async () => {
+    const factory = new IDBFactory()
+    const database = `local-scope-race-${crypto.randomUUID()}`
+    const identityModel = model<{ me: { id: string } | null }>({ me: null })
+    const identityStore = identityModel.instance()
+    identityStore.proxy.me = { id: '1' }
+    const source = local.collection<TodoEntity>({
+      key: 'scope-race-todos',
+      version: 1,
+      scope: ({ state }) => {
+        const id = state(identityModel).me?.id
+        return id ? `user:${id}` : null
+      },
+    })
+    const pending = deferred<TodoListItem[]>()
+    const listFn = vi
+      .fn<() => Promise<TodoListItem[]>>()
+      .mockResolvedValueOnce([
+        { id: '1', title: 'User one', status: 'open' as const, updatedAt: 1 },
+      ])
+      .mockImplementationOnce(() => pending.promise)
+    const todoModel = model({
+      list: local.query<TodoListItem[]>({
+        source,
+        initialData: [],
+        queryFn: listFn,
+      }),
+    })
+    const store = todoModel.instance()
+    const registry = createQueryBindingRegistry({ local: { indexedDB: factory, database } })
+    registry.getModelState = () => identityStore.proxy
+    const bound = bindResourceState(
+      store.proxy,
+      todoModel.pluginBags.get('query')!,
+      undefined,
+      registry,
+      todoModel.key
+    ) as any
+
+    await bound.list.query()
+    const request = bound.list.query({ force: true })
+    identityStore.proxy.me = { id: '2' }
+    pending.resolve([{ id: '1', title: 'Late user one', status: 'open' as const, updatedAt: 2 }])
+    await request
+
+    expect(bound.list.data).toEqual([])
+    expect(bound.list.isSuccess).toBe(false)
+
+    const userTwoQuery = vi.fn(() => [
+      { id: '1', title: 'Fresh user two', status: 'open' as const, updatedAt: 1 },
+    ])
+    const userTwoModel = model({
+      list: local.query<TodoListItem[]>({
+        source,
+        initialData: [],
+        staleTime: 60_000,
+        queryFn: userTwoQuery,
+      }),
+    })
+    const userTwoStore = userTwoModel.instance()
+    const userTwoRegistry = createQueryBindingRegistry({
+      local: { indexedDB: factory, database },
+    })
+    userTwoRegistry.getModelState = () => identityStore.proxy
+    const userTwo = bindResourceState(
+      userTwoStore.proxy,
+      userTwoModel.pluginBags.get('query')!,
+      undefined,
+      userTwoRegistry,
+      userTwoModel.key
+    ) as any
+
+    await userTwo.list.query()
+    expect(userTwoQuery).toHaveBeenCalledOnce()
+    expect(userTwo.list.data[0].title).toBe('Fresh user two')
   })
 
   test('normalizes and restores response envelopes with map.split/join', async () => {

--- a/packages/comwit/tests/query-selector-load.test.tsx
+++ b/packages/comwit/tests/query-selector-load.test.tsx
@@ -66,6 +66,28 @@ describe('query selector load', () => {
     expect(result.current.data).toBe(42)
   })
 
+  test('loads from a frozen snapshot produced by model extensions', async () => {
+    const queryFn = vi.fn().mockResolvedValue(['book'])
+    const products = model(
+      {
+        list: query<string[]>({ initialData: [], queryFn }),
+      },
+      {
+        derive: (state) => ({
+          count: () => state.list.data.length,
+        }),
+      }
+    )
+
+    const { result } = renderHook(() => useModel(products, (state) => state.list.load()), {
+      wrapper: Wrapper,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(queryFn).toHaveBeenCalledOnce()
+    expect(result.current.data).toEqual(['book'])
+  })
+
   test('treats an option-shaped object as the declared query argument', async () => {
     const queryFn = vi.fn(({ force }: { force: boolean }) => Promise.resolve(String(force)))
     const search = model({

--- a/packages/comwit/tests/snapshot-types.test.ts
+++ b/packages/comwit/tests/snapshot-types.test.ts
@@ -182,3 +182,18 @@ test('standalone local resources expose restore in selectors and exact set in ac
 
   void standaloneLocalTypeContract
 })
+
+test('local collections require getId only when the entity has no default id', () => {
+  type ExternalProduct = { uuid: string; title: string }
+
+  local.collection<ExternalProduct>({
+    key: 'external-products',
+    version: 1,
+    getId: (product) => product.uuid,
+  })
+
+  // @ts-expect-error Entities without `id` must provide an identity extractor.
+  local.collection<ExternalProduct>({ key: 'missing-get-id', version: 1 })
+
+  local.collection<{ id: string; title: string }>({ key: 'default-id', version: 1 })
+})

--- a/packages/comwit/tests/snapshot-types.test.ts
+++ b/packages/comwit/tests/snapshot-types.test.ts
@@ -2,13 +2,14 @@ import { expectTypeOf, test } from 'vitest'
 import {
   action,
   create,
+  local,
   model,
   query,
   snapshot,
   useModel,
   type SelectableResourceState,
 } from '../src'
-import type { Query } from '../src'
+import type { Local, Query } from '../src'
 import { createProxy } from '../src/core/proxy'
 
 // `.snapshot()` is exposed on the top-level proxy at the type level. For
@@ -147,3 +148,37 @@ function selectorLoadTypeContract() {
 }
 
 void selectorLoadTypeContract
+
+test('standalone local resources expose restore in selectors and exact set in actions', () => {
+  type Product = { id: string; title: string }
+  type DetailArg = { id: string }
+  type DetailState = SelectableResourceState<{
+    detail: Local<Product | null, DetailArg>
+  }>
+
+  expectTypeOf<DetailState['detail']['restore']>().parameter(0).toEqualTypeOf<DetailArg>()
+  expectTypeOf<
+    ReturnType<DetailState['detail']['restore']>['data']
+  >().toEqualTypeOf<Product | null>()
+
+  const products = local.collection<Product>({ key: 'products', version: 1 })
+  const m = model({
+    detail: local<Product | null, DetailArg>({
+      source: products,
+      initialData: null,
+    }),
+  })
+
+  action(({ state }) => {
+    const s = state(m)
+    s.detail.set({ id: '1', title: 'Server' }, { arg: { id: '1' } })
+    s.detail.remove({ id: '1' })
+    return {}
+  })
+
+  function standaloneLocalTypeContract() {
+    useModel(m, (state) => state.detail.restore({ id: '1' }).data)
+  }
+
+  void standaloneLocalTypeContract
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,11 @@ extend@^3.0.0:
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+fake-indexeddb@^6.2.4:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz#74285b6821467d6c102af092f0a4517ad5521613"
+  integrity sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"


### PR DESCRIPTION
## Summary

- Add standalone `local()` resources with exact IndexedDB restore, set, and remove methods and no API driver.
- Add `local.query()` and `local.infinite()` as optional server revalidation adapters while preserving the existing load, query, refetch, set, status, and optimistic mutation interfaces.
- Normalize list, detail, and infinite views over shared entity collections with default `id` identity, custom `getId`, response-envelope maps, merge/revision hooks, and optimistic fan-out.
- Add static and lazy collection scopes for public, user, and tenant caches. Returning null from a scope resolver safely skips IndexedDB instead of falling back to a shared scope.
- Keep collection identity separate from exact view membership and freshness, including same-view progressive enrichment through async iterable query results.
- Support Next.js server-rendered SEO details with exact fallback restore and server initialization that wins pending local reads.
- Skip the IndexedDB lifecycle without throwing in server environments and degrade storage failures to ordinary query behavior.
- Keep query internals independent from local, IndexedDB, and collections through neutral resource lifecycle hooks.
- Document provider scope, collection versions, normalized storage, freshness boundaries, optimistic updates, progressive enrichment, and the `persist()` boundary in the API and LLM guides.
- Retain the beta.0 wrapper as a deprecated compatibility form.

## Verification

- Vitest runtime and typecheck suites
- TypeScript typecheck
- Library production build and declaration generation
- Next.js documentation production build, re-run after the documentation update
- Prettier and `git diff --check`
- npm package dry-runs and registry verification

## Published

- `@comwit/state@2.2.0-beta.3`
- `comwit@2.2.0-beta.3`
- `latest` remains `2.1.0`; `beta` points to `2.2.0-beta.3`