### PR TITLE
fix(local): preserve canonical fields during revalidation

### DIFF
--- a/apps/docs/content/blog/v2.2.1-release.mdx
+++ b/apps/docs/content/blog/v2.2.1-release.mdx
@@ -1,0 +1,29 @@
+---
+title: 'comwit v2.2.1 — Stable local revalidation'
+date: '2026-08-17'
+description: 'v2.2.1 keeps canonical entity fields visible throughout ordinary and streamed local query revalidation.'
+author: 'Codex'
+---
+
+## Canonical fields stay visible during revalidation
+
+`local.query()` and `local.infinite()` now apply the collection's entity merge contract before a
+remote result becomes observable. A partial list response therefore cannot temporarily remove a
+field that was already stored by a detail resource or a local mutation.
+
+The same guarantee applies to every `AsyncIterable` chunk. Local-first screens can continue showing
+their durable entity data while a streamed background refresh incrementally supplies new fields and
+view metadata.
+
+Explicit properties in the remote fragment still update or clear canonical values. Only omitted
+properties are preserved by the default shallow merge, and custom `merge` and `revision` policies
+continue to take precedence.
+
+Upgrade:
+
+```bash
+yarn add @comwit/state@2.2.1
+```
+
+See the complete [`local()` reference](/docs/api/local) for normalized collection and revalidation
+behavior.

--- a/apps/docs/content/docs/api/local.mdx
+++ b/apps/docs/content/docs/api/local.mdx
@@ -227,6 +227,7 @@ exact local view found and stale
 → show it immediately
 → isLoading: false, isFetching: true
 → run queryFn in the background
+→ merge each remote result with canonical entities before observers update
 → commit canonical entities and current view atomically
 
 exact local view missing
@@ -236,6 +237,11 @@ exact local view missing
 If revalidation fails, the local data remains visible with `isSuccess: true` and `isError: true`.
 Visible fields may change when the server response arrives; use `isFetching` for a subtle update
 indicator and copy actively edited forms into separate draft state.
+
+Remote fragments use the collection's normal `merge` behavior before they become observable. This
+also applies to every `AsyncIterable` chunk, so a streamed list revalidation cannot temporarily
+drop fields that only a detail resource or local mutation supplied. Returning a property explicitly
+still updates or clears it; omitting the property preserves its canonical value.
 
 `local.infinite()` accepts the ordinary infinite query options and stores flattened ID ordering,
 cursor, `hasMore`, and cursor history:

--- a/packages/comwit/package.json
+++ b/packages/comwit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comwit/state",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": false,
   "homepage": "https://library.comwit.io",
   "repository": {

--- a/packages/comwit/src/core/local.ts
+++ b/packages/comwit/src/core/local.ts
@@ -669,7 +669,10 @@ function entityId(
   return undefined
 }
 
-function normalizeState(state: ResourceDataLike, metadata: LocalResourceMetadata): NormalizedState {
+function normalizeState(
+  state: Readonly<ResourceDataLike>,
+  metadata: LocalResourceMetadata
+): NormalizedState {
   const plain = snapshot(state) as ResourceDataLike
   const data = plain.data
   let dataKind: DataKind
@@ -726,22 +729,19 @@ function normalizeState(state: ResourceDataLike, metadata: LocalResourceMetadata
 }
 
 function hydrateData(
-  view: ViewRecord,
-  records: EntityRecord[],
+  view: Pick<ViewRecord, 'dataKind' | 'dataMeta'>,
+  values: LocalEntity[],
   metadata: LocalResourceMetadata
 ): unknown {
   if (view.dataKind === 'null') return null
-  if (view.dataKind === 'entity') return records[0]?.value ?? null
+  if (view.dataKind === 'entity') return values[0] ?? null
   if (view.dataKind === 'mapped') {
     if (!metadata.map) {
       throw new Error('local() view requires the map option that created it')
     }
-    return metadata.map.join(
-      records.map((record) => record.value),
-      view.dataMeta
-    )
+    return metadata.map.join(values, view.dataMeta)
   }
-  return records.map((record) => record.value)
+  return values
 }
 
 function compareRevision(
@@ -932,7 +932,11 @@ class LocalManager {
       }
 
       return {
-        data: hydrateData(stored.view, stored.entities, binding.metadata),
+        data: hydrateData(
+          stored.view,
+          stored.entities.map((record) => record.value),
+          binding.metadata
+        ),
         state: stored.view.state,
         fetchedAt: stored.view.fetchedAt,
         cursorHistory: [...stored.view.cursorHistory],
@@ -945,6 +949,49 @@ class LocalManager {
       })
       return undefined
     }
+  }
+
+  reconcileRemoteEmission(
+    binding: LocalResourceBinding,
+    previousState: Readonly<ResourceDataLike>,
+    requestStartRevision: number
+  ): void {
+    const activeView = binding.activeView
+    if (!activeView) return
+
+    let incoming: NormalizedState
+    try {
+      incoming = normalizeState(binding.state, binding.metadata)
+    } catch (error) {
+      this.report(error, {
+        operation: 'normalize',
+        collection: binding.metadata.source.key,
+        resource: binding.resource,
+      })
+      return
+    }
+
+    let previous: NormalizedState | undefined
+    try {
+      previous = normalizeState(previousState, binding.metadata)
+    } catch {
+      // The active collection cache below remains a valid fallback for a new view.
+    }
+
+    const collection = binding.metadata.source
+    const previousById = new Map(
+      (previous?.entities ?? []).map((entity) => [idToken(entity.id), entity.value])
+    )
+    const values = incoming.entities.map(({ id, value }) => {
+      const cached = this.entityCache.get(this.entityCacheKey(activeView.scope, collection, id))
+      const protectLocal = cached !== undefined && cached.localRevision > requestStartRevision
+      if (protectLocal) return cached.value
+
+      const current = previousById.get(idToken(id)) ?? cached?.value
+      return mergeEntity(collection, current, value)
+    })
+
+    binding.applyRemoteEmission(incoming, values)
   }
 
   async commitRemote(
@@ -1315,6 +1362,21 @@ export class LocalResourceBinding {
     return hydrated
   }
 
+  reconcileRemoteEmission(
+    previousState: Readonly<ResourceDataLike>,
+    requestToken: LocalRequestToken
+  ): void {
+    const resolvedScope = this.resolveScope()
+    if (
+      !requestToken.scope ||
+      requestToken.scope !== resolvedScope ||
+      this.activeView?.scope !== resolvedScope
+    ) {
+      return
+    }
+    this.manager.reconcileRemoteEmission(this, previousState, requestToken.revision)
+  }
+
   async commitRemote(
     entry: QueryCacheEntry,
     fetchedAt: number,
@@ -1352,9 +1414,19 @@ export class LocalResourceBinding {
     entry.state = snapshot(this.state) as ResourceDataLike
   }
 
+  applyRemoteEmission(incoming: NormalizedState, values: LocalEntity[]): void {
+    this.runInternal(() => {
+      this.state.data = hydrateData(incoming, values, this.metadata)
+    })
+  }
+
   applyView(view: ViewRecord, records: EntityRecord[]): void {
     this.runInternal(() => {
-      this.state.data = hydrateData(view, records, this.metadata)
+      this.state.data = hydrateData(
+        view,
+        records.map((record) => record.value),
+        this.metadata
+      )
       Object.assign(this.state, view.state)
     })
     this.syncActiveCache()
@@ -1476,6 +1548,14 @@ function createLocalLifecycleFactory(): ResourceLifecycleFactory {
         },
         beginRequest() {
           return binding.currentRevision()
+        },
+        afterApply({ previousState, requestToken }) {
+          binding.reconcileRemoteEmission(
+            previousState,
+            requestToken && typeof requestToken === 'object'
+              ? (requestToken as LocalRequestToken)
+              : { revision: 0 }
+          )
         },
         afterSuccess({ entry, fetchedAt, requestToken }) {
           return binding.commitRemote(

--- a/packages/comwit/src/core/query/accessor.ts
+++ b/packages/comwit/src/core/query/accessor.ts
@@ -330,6 +330,25 @@ export function createResourceAccessor(
 
   const beginLifecycleRequests = () => lifecycleBindings.map((binding) => binding.beginRequest?.())
 
+  const applyRemoteResult = (result: unknown, appendData: boolean, requestTokens: unknown[]) => {
+    const shouldReconcile = lifecycleBindings.some((binding) => binding.afterApply)
+    const previousState = shouldReconcile
+      ? (snapshot(state) as Readonly<ResourceDataLike>)
+      : undefined
+
+    runInternal(() => mergeResult(state, result, appendData))
+
+    if (!previousState) return
+    lifecycleBindings.forEach((binding, index) =>
+      binding.afterApply?.({
+        previousState,
+        result,
+        appendData,
+        requestToken: requestTokens[index],
+      })
+    )
+  }
+
   const commitLifecycleSuccess = async (
     entry: QueryCacheEntry,
     fetchedAt: number,
@@ -652,7 +671,7 @@ export function createResourceAccessor(
             }
 
             lastYield = chunk
-            runInternal(() => mergeResult(state, chunk))
+            applyRemoteResult(chunk, false, requestTokens)
           }
         } catch (streamError) {
           if (abortController.signal.aborted) {
@@ -677,9 +696,9 @@ export function createResourceAccessor(
 
       // Non-streaming path (original behavior)
       if (descriptor.kind === 'single' || descriptor.kind === 'realtime') {
-        runInternal(() => mergeResult(state, result))
+        applyRemoteResult(result, false, requestTokens)
       } else {
-        runInternal(() => mergeResult(state, result, mode === 'append'))
+        applyRemoteResult(result, mode === 'append', requestTokens)
       }
 
       state.isSuccess = true

--- a/packages/comwit/src/core/query/types.ts
+++ b/packages/comwit/src/core/query/types.ts
@@ -441,10 +441,22 @@ export type ResourceLifecycleSuccessContext = {
   requestToken: unknown
 }
 
+export type ResourceLifecycleApplyContext = {
+  /** Resource state immediately before this remote result or stream chunk was applied. */
+  previousState: Readonly<ResourceDataLike>
+  /** The raw value returned by the query driver. */
+  result: unknown
+  /** Whether an infinite query appended this result to the current data. */
+  appendData: boolean
+  requestToken: unknown
+}
+
 export type ResourceLifecycleBinding = {
   activate?(key: QueryCacheKey, arg: unknown): void
   hydrate?(): Promise<ResourceHydratedView | undefined>
   beginRequest?(): unknown
+  /** Reconcile an applied remote value synchronously before observers flush. */
+  afterApply?(context: ResourceLifecycleApplyContext): void
   afterSuccess?(context: ResourceLifecycleSuccessContext): Promise<void> | void
   runInternal?<T>(callback: () => T): T
   preserveSuccessOnError?: boolean

--- a/packages/comwit/tests/local.test.ts
+++ b/packages/comwit/tests/local.test.ts
@@ -400,6 +400,85 @@ describe('local()', () => {
     expect(bound.detail.data.description).toBe('Only the detail endpoint knows this')
   })
 
+  test('preserves canonical fields while a streamed revalidation is still in progress', async () => {
+    const factory = new IDBFactory()
+    const database = `local-stream-revalidate-${crypto.randomUUID()}`
+    const source = local.collection<TodoEntity>({ key: 'todos', version: 1 })
+    const continueStream = deferred<void>()
+    const firstChunkApplied = deferred<void>()
+    let requestCount = 0
+    type TodoPage = { items: TodoListItem[]; total: number }
+
+    async function* listFn() {
+      requestCount++
+      if (requestCount === 1) {
+        yield {
+          items: [{ id: '1', title: 'Initial', status: 'open' as const, updatedAt: 1 }],
+          total: 1,
+        }
+        return
+      }
+
+      yield {
+        items: [{ id: '1', title: 'Refreshed', status: 'open' as const, updatedAt: 3 }],
+        total: 1,
+      }
+      firstChunkApplied.resolve()
+      await continueStream.promise
+    }
+
+    const todoModel = model({
+      list: local.query<TodoPage, { status: 'open' | 'done' }>({
+        source,
+        initialData: { items: [], total: 0 },
+        staleTime: 0,
+        queryFn: listFn,
+        map: {
+          split: (page) => ({ rows: page.items, meta: { total: page.total } }),
+          join: (rows, meta) => ({ items: rows, total: meta?.total ?? 0 }),
+        },
+      }),
+      detail: local.query<TodoDetail | null, string>({
+        source,
+        initialData: null,
+        queryFn: () => ({
+          id: '1',
+          title: 'Detail',
+          status: 'open' as const,
+          updatedAt: 2,
+          description: 'Only the detail endpoint knows this',
+        }),
+      }),
+    })
+    const store = todoModel.instance()
+    const bound = bindResourceState(
+      store.proxy,
+      todoModel.pluginBags.get('query')!,
+      undefined,
+      createQueryBindingRegistry({ local: { indexedDB: factory, database } }),
+      todoModel.key
+    ) as any
+
+    await bound.list.query({ status: 'open' })
+    await bound.detail.query('1')
+
+    const refetch = bound.list.refetch()
+    await firstChunkApplied.promise
+
+    expect(bound.list.data.items[0]).toEqual({
+      id: '1',
+      title: 'Refreshed',
+      status: 'open',
+      updatedAt: 3,
+      description: 'Only the detail endpoint knows this',
+    })
+    expect(bound.list.data.total).toBe(1)
+    expect(bound.list.isFetching).toBe(true)
+
+    continueStream.resolve()
+    await refetch
+  })
+
   test('fans an optimistic entity edit out to loaded views and persists it', async () => {
     const factory = new IDBFactory()
     const database = `local-optimistic-${crypto.randomUUID()}`


### PR DESCRIPTION
## Summary

- reconcile every remote query result with canonical local entities before observers flush
- apply the same merge guarantee to each AsyncIterable chunk and mapped response envelope
- preserve local revision protection while keeping incoming view membership and metadata
- document the behavior and prepare the 2.2.1 patch release

## Problem

A stale `local.query()` restored canonical entities from IndexedDB, but then exposed a raw partial server result before the local adapter reconciled and persisted it. During streamed revalidation, fields supplied only by another resource or a local mutation temporarily disappeared from observable state.

## Verification

- `yarn workspace @comwit/state test` (370 tests)
- `yarn workspace @comwit/state typecheck`
- `yarn workspace @comwit/state build`
- regression coverage for `map.split/join` with an in-progress `AsyncIterable` revalidation